### PR TITLE
Add Applicative instance for ReadM

### DIFF
--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -107,6 +107,10 @@ newtype ReadM a = ReadM
 instance Functor ReadM where
   fmap f (ReadM m) = ReadM (fmap f m)
 
+instance Applicative ReadM where
+  pure = ReadM . Right
+  ReadM b <*> ReadM a = ReadM (b <*> a)
+
 instance Monad ReadM where
   return = ReadM . Right
   ReadM m >>= f = ReadM $ m >>= runReadM . f


### PR DESCRIPTION
Is there a reason why this instance shouldn't exist that I haven't thought of?
