### PR TITLE
Add very simple execParserMaybe pure parser function for type "Parser a -> String -> Maybe a".

### DIFF
--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -6,13 +6,14 @@ module Options.Applicative.Extra (
   helper,
   execParser,
   execParserPure,
+  execParserMaybe,
   customExecParser,
   usage,
   ParserFailure(..),
   ) where
 
 import Control.Applicative ((<$>), (<|>))
-import Data.Monoid (mconcat)
+import Data.Monoid (mconcat, mempty)
 import System.Environment (getArgs, getProgName)
 import System.Exit (exitWith, ExitCode(..))
 import System.IO (hPutStr, stderr)
@@ -79,6 +80,12 @@ execParserPure pprefs pinfo args =
     parser' = (Extra <$> bashCompletionParser parser pprefs)
           <|> (Result <$> parser)
     p = runParserFully parser' args
+
+execParserMaybe :: (Parser a) -> [String] -> Maybe a
+execParserMaybe parser = eitherToMaybe . execParserPure preferences information
+  where information   = (info parser mempty)
+        preferences   = prefs mempty
+        eitherToMaybe = either (const Nothing) Just
 
 parserFailure :: ParserPrefs -> ParserInfo a
               -> ParseError -> Context


### PR DESCRIPTION
I like the idea of being able to use my option-parsers in a completely IO free manner, making many other approaches than the canonical example possible. Optparse-Applicative was the only library that allowed me to do this that I found, but the code required took a little bit of time to construct.

Let me know if you're interested in this kind of change, if so I might have some more :)
