### PR TITLE
Export ParserPrefs from Common

### DIFF
--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -32,7 +32,11 @@ module Options.Applicative.Common (
   --
   -- A basic 'ParserInfo' with default values for fields can be created using
   -- the 'info' function.
+  --
+  -- A 'ParserPrefs' contains general preferences for all command-line
+  -- options, and can be built with the 'prefs' function.
   ParserInfo(..),
+  ParserPrefs(..),
 
   -- * Running parsers
   runParserInfo,


### PR DESCRIPTION
Since otherwise to give a type signature to the result of `prefs` (which _is_ exported), you have to add an import to `Types`.
