### PR TITLE
Add quick installation and import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ parsers.
 
 ## Getting started
 
+Install with
+
+```sh
+cabal install optparse-applicative
+```
+
+and import with
+
+```haskell
+import Options.Applicative
+```
+
 Here is a simple example of an applicative option parser:
 
 ```haskell


### PR DESCRIPTION
When I started trying to use this library I had to go look up which module to import on Hackage, so I thought it would be nice to have it at the start of the getting started tutorial. It might also be nice to say how to install it, so people don't have to know the package name.
