### PR TITLE
Divide subparsers by propMetaVar in parserHelp

### DIFF
--- a/Options/Applicative.hs
+++ b/Options/Applicative.hs
@@ -34,5 +34,3 @@ import Options.Applicative.Common
 import Options.Applicative.Builder
 import Options.Applicative.Builder.Completer
 import Options.Applicative.Extra
-
-{-# ANN module "HLint: ignore Use import/export shortcut" #-}

--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -185,7 +185,7 @@ command cmd pinfo = fieldMod $ \p ->
 -- | Add a command to a subparser option with specified list of aliases.
 command' :: String -> [String] -> ParserInfo a -> Mod CommandFields a
 command' cmd [] pinfo = command cmd pinfo
-command' cmd as pinfo = foldl (\c a -> commandAlias a pinfo <> c) (command cmd pinfo') as
+command' cmd as pinfo = foldl (\c a -> commandAlias a pinfo `mappend` c) (command cmd pinfo') as
   where pinfo' = pinfo { infoProgDesc = desc }
         desc = vcatChunks [infoProgDesc pinfo, paragraph $ "Aliases: " ++ intercalate ", " as ++ "."]
 

--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -184,11 +184,10 @@ command cmd pinfo = fieldMod $ \p ->
 
 -- | Add a command to a subparser option with specified list of aliases.
 command' :: String -> [String] -> ParserInfo a -> Mod CommandFields a
-command' cmd as pinfo = foldl (\c al -> commandAlias al pinfo <> c) (command cmd pinfo') as
-  where pinfo' = pinfo { infoProgDesc =
-                           vcatChunks $
-                           [infoProgDesc pinfo, paragraph $ "Aliases: " ++ intercalate ", " as ++ "."]
-                           }
+command' cmd [] pinfo = command cmd pinfo
+command' cmd as pinfo = foldl (\c a -> commandAlias a pinfo <> c) (command cmd pinfo') as
+  where pinfo' = pinfo { infoProgDesc = desc }
+        desc = vcatChunks [infoProgDesc pinfo, paragraph $ "Aliases: " ++ intercalate ", " as ++ "."]
 
 -- | Add a commandAlias to a subparser option.
 commandAlias :: String -> ParserInfo a -> Mod CommandFields a

--- a/Options/Applicative/Builder/Internal.hs
+++ b/Options/Applicative/Builder/Internal.hs
@@ -70,6 +70,8 @@ instance HasValue OptionFields where
   hasValueDummy _ = ()
 instance HasValue ArgumentFields where
   hasValueDummy _ = ()
+instance HasValue CommandFields where
+  hasValueDummy _ = ()
 
 class HasMetavar f where
   hasMetavarDummy :: f a -> ()

--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -91,9 +91,7 @@ instance Monoid MatchResult where
 argMatches :: MonadP m => OptReader a -> String
            -> Maybe (StateT Args m a)
 argMatches opt arg = case opt of
-  ArgReader rdr -> Just $ do
-    result <- lift $ runReadM (crReader rdr) arg
-    return result
+  ArgReader rdr -> Just . lift $ runReadM (crReader rdr) arg
   CmdReader _ f ->
     flip fmap (f arg) $ \subp -> StateT $ \args -> do
       setContext (Just arg) subp

--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -47,7 +47,7 @@ helper = abortOption ShowHelpText $ mconcat
 hsubparser :: Mod CommandFields a -> Parser a
 hsubparser m = mkParser d g rdr
   where
-    Mod _ d g = m `mappend` metavar "COMMAND"
+    Mod _ d g = metavar "COMMAND" `mappend` m
     (cmds, subs) = mkCommand m
     rdr = CmdReader cmds (fmap add_helper . subs)
     add_helper pinfo = pinfo

--- a/Options/Applicative/Help/Core.hs
+++ b/Options/Applicative/Help/Core.hs
@@ -135,12 +135,12 @@ parserHelp pprefs p = bodyHelp . vsepChunks $
     mkTitle :: String -> String
     mkTitle t = "Available " ++ map toLower t ++ ":"
     gather :: [(String, Chunk Doc)] -> [(String, Chunk Doc)]
-    gather l = gather' l []
+    gather = reverse . flip gather' []
     gather' :: [(String, Chunk Doc)] -> [(String, Chunk Doc)] -> [(String, Chunk Doc)]
     gather' [] acc = acc
     gather' ((a, b):xs) acc = case lookup a acc of
                                  Just _ -> gather' xs (insert a b acc)
-                                 Nothing -> gather' xs ((a, b): acc)
+                                 Nothing -> gather' xs ((a, b) : acc)
     insert :: String -> Chunk Doc -> [(String, Chunk Doc)] -> [(String, Chunk Doc)]
     insert _ _ [] = []
     insert key d ((a, b):l) = if a == key

--- a/Options/Applicative/Help/Core.hs
+++ b/Options/Applicative/Help/Core.hs
@@ -14,7 +14,7 @@ module Options.Applicative.Help.Core (
 
 import Control.Monad (guard)
 import Data.List (intersperse, sort)
-import Data.Maybe (maybeToList, catMaybes)
+import Data.Maybe (maybeToList, catMaybes, fromMaybe)
 import Data.Char (toLower)
 import Data.Monoid (mempty, mappend)
 
@@ -65,9 +65,9 @@ cmdDesc = mapParser desc
   where desc _ opt = (,) (propMetaVar . optProps $ opt) $
           case optMain opt of
             CmdReader cmds p ->
-              tabulate [(string cmd,align (extractChunk d))
-                       | cmd <- reverse cmds
-                       , d <- maybeToList . fmap infoProgDesc $ p cmd]
+             tabulate [(string cmd, align (extractChunk d))
+                      | cmd <- reverse . filter (fromMaybe False . fmap (not . isHidden) . p) $ cmds
+                      , d <- maybeToList . fmap infoProgDesc $ p cmd]
             _ -> mempty
 
 -- | Generate a brief help text for a parser.
@@ -153,6 +153,3 @@ parserUsage pprefs p progn = hsep
   [ string "Usage:"
   , string progn
   , align (extractChunk (briefDesc pprefs p)) ]
-
-
-{-# ANN footerHelp "HLint: ignore Eta reduce" #-}

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -74,7 +74,8 @@ data ParserInfo a = ParserInfo
   , infoFooter :: Chunk Doc   -- ^ footer of the full parser description
   , infoFailureCode :: Int    -- ^ exit code for a parser failure
   , infoIntersperse :: Bool   -- ^ allow regular options and flags to occur
-                              -- after arguments (default: True)
+                              -- after arguments (default: True))
+  , isHidden :: Bool
   }
 
 instance Functor ParserInfo where


### PR DESCRIPTION
Fixing #121

Tried to make clean fix, but run into problems with gather function (it is needed to cover situations when library user defines few subparsers without providing metavar or defines few subparsers with same metavar). 

OK, what we have after this update. Suppose I have written:

```haskell
cmd :: String -> Parser a -> String -> Mod CommandFields a
cmd s p d =
  command s (info p (progDesc d))

parser1 :: Parser Int
parser1 =
  subparser $
  metavar "INT" <>
  cmd "one" (pure 1) "Got 1" <>
  cmd "two" (pure 2) "Got 2"

parser2 :: Parser Char
parser2 =
  subparser $
  metavar "CHAR" <>
  cmd "lol" (pure 'a') "Got a" <>
  cmd "hel" (pure 'b') "Got b"

parser3 :: Parser Bool
parser3 =
  subparser $
  cmd "no" (pure True) "Got true" <>
  cmd "yes" (pure False) "Got false"

parser4 :: Parser (Maybe Bool)
parser4 =
  subparser $
  cmd "just yes" (pure (Just True)) "Got Just true" <>
  cmd "nothing" (pure Nothing) "Got nothing"

test :: ParserInfo (Int, Char, Bool, Maybe Bool)
test = info (helper <*> ((,,,) <$> parser1 <*> parser2 <*> parser3 <*> parser4)) idm
```

And when I do

```
> :set args --help
> execParser test
```

I got fancy result:

```
Usage: <interactive> INT CHAR COMMAND COMMAND

Available options:
  -h,--help                Show this help text

Available commands:
  no                       Got true
  yes                      Got false
  just yes                 Got Just true
  nothing                  Got nothing

Available chars:
  lol                      Got a
  hel                      Got b

Available ints:
  one                      Got 1
  two                      Got 2
*** Exception: ExitSuccess
```

The only problems I actually see are:

* using `metavar "OPTION"` is allowed (so user will see "Available options:" twice) - it's not that critical and can be easily avoided
* using `metavar "CHARS"` will lead to "Available charss:". I see few solutions here:
  * not adding 's' character to the end of title, when it already has one there
  * not lowering title, so in this case user will see "Available CHARSs:"
  * not adding 's' character to custom titles at all [+ not lowering title]

I leave this questions open (so maintainers can use best solution they think of). 

BTW, after running tests I've got

```
All 43 tests passed (0.67s)
```