### PR TITLE
Allow for unix style short args, i.e., -xcf

### DIFF
--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -119,8 +119,11 @@ optMatches disambiguate opt (OptWord arg1 val) = case opt of
       lift $ runReadM (withReadM (errorFor arg1) (crReader rdr)) arg'
   FlagReader names x -> do
     guard $ has_name arg1 names
-    guard $ isNothing val
-    Just $ return x
+    Just $ do
+      args <- get
+      let val' = (\s -> '-' : s) <$> val
+      put $ maybeToList val' ++ args
+      return x
   _ -> Nothing
   where
     errorFor name msg = "option " ++ showOption name ++ ": " ++ msg

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -351,6 +351,37 @@ case_arg_order_3 = do
     Success res -> (3, 5) @=? res
     _ -> assertFailure "unexpected parse error"
 
+case_unix_style :: Assertion
+case_unix_style = do
+  let p = (,)
+          <$> flag' (1 :: Int) (short 'x')
+          <*> flag' (2 :: Int) (short 'c')
+      i = info p idm
+      result = run i ["-xc"]
+  case result of
+    Success res -> (1, 2) @=? res
+    _ -> assertFailure "unexpected parse error"
+
+case_unix_with_options :: Assertion
+case_unix_with_options = do
+  let p = (,)
+          <$> flag' (1 :: Int) (short 'x')
+          <*> strOption (short 'a')
+      i = info p idm
+      result = run i ["-xac"]
+  case result of
+    Success res -> (1, "c") @=? res
+    _ -> assertFailure "unexpected parse error"
+
+case_count_flags :: Assertion
+case_count_flags = do
+  let p = length <$> many (flag' () (short 't'))
+      i = info p idm
+      result = run i ["-ttt"]
+  case result of
+    Success res -> 3 @=? res
+    _ -> assertFailure "unexpected parse error"
+
 case_issue_47 :: Assertion
 case_issue_47 = do
   let p = option r (long "test" <> value 9) :: Parser Int


### PR DESCRIPTION
Most command parsers (getOpts and the like) allow for unix style short commands, which can be concatenated together, for example, tar -xcf.