### PR TITLE
Fix link to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ simplified implementation.
 
  [status-png]: https://api.travis-ci.org/pcapriotti/optparse-applicative.svg
  [status]: http://travis-ci.org/pcapriotti/optparse-applicative?branch=master
- [blog]: http://paolocapriotti.com/blog/2012/04/27/applicative-option-parser/
+ [blog]: http://www.paolocapriotti.com/blog/2012/04/27/applicative-option-parser/
  [builder-documentation]: http://hackage.haskell.org/package/optparse-applicative/docs/Options-Applicative-Builder.html
  [hackage-png]: http://img.shields.io/hackage/v/optparse-applicative.svg
  [hackage]: http://hackage.haskell.org/package/optparse-applicative


### PR DESCRIPTION
The github pages settings for paolocapriotti.com require it to be prefixed by `www`. So you could merge this PR or modify your site [CNAME](https://github.com/pcapriotti/pcapriotti.github.com/blob/master/CNAME) to remove the `www`. Not sure of all the side effects of the latter but I have my own github pages site configured without the `www` and it seems to work fine.