### PR TITLE
Bump transformers-compat upper version bounds

### DIFF
--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -111,6 +111,6 @@ library
   ghc-options:         -Wall
   build-depends:       base == 4.*,
                        transformers >= 0.2 && < 0.5,
-                       transformers-compat == 0.3.*,
+                       transformers-compat >= 0.3 && < 0.5,
                        process >= 1.0 && < 1.3,
                        ansi-wl-pprint >= 0.6 && < 0.7

--- a/tests/optparse-applicative-tests.cabal
+++ b/tests/optparse-applicative-tests.cabal
@@ -31,7 +31,7 @@ executable optparse-applicative-tests
                        HUnit == 1.2.*,
                        QuickCheck >= 2.6 && < 2.8,
                        transformers >= 0.2 && < 0.5,
-                       transformers-compat == 0.3.*,
+                       transformers-compat >= 0.3 && < 0.5,
                        process >= 1.0 && < 1.3,
                        ansi-wl-pprint >= 0.6 && < 0.7,
                        tasty >= 0.8 && < 0.11,


### PR DESCRIPTION
Allow `optparse-applicative` to use `transformers-compat-0.4.0.*`. Right now, this is causing `cabal` to default to a much older `optparse-applicative` when trying to install `tasty`, which is wreaking havoc on my Travis-CI builds ([example](https://travis-ci.org/RyanGlScott/text-show/jobs/50684133)).