### PR TITLE
Add defaultPrefs, a default preferences value

### DIFF
--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -84,6 +84,7 @@ module Options.Applicative.Builder (
   noBacktrack,
   columns,
   prefs,
+  defaultPrefs,
 
   -- * Types
   Mod,
@@ -388,3 +389,7 @@ prefs m = applyPrefsMod m base
 -- | Trivial option modifier.
 idm :: Monoid m => m
 idm = mempty
+
+-- | Default preferences.
+defaultPrefs :: ParserPrefs
+defaultPrefs = prefs idm

--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -58,7 +58,7 @@ hsubparser m = mkParser d g rdr
 -- Parse command line arguments. Display help text and exit if any parse error
 -- occurs.
 execParser :: ParserInfo a -> IO a
-execParser = customExecParser (prefs idm)
+execParser = customExecParser defaultPrefs
 
 -- | Run a program description with custom preferences.
 customExecParser :: ParserPrefs -> ParserInfo a -> IO a
@@ -102,7 +102,7 @@ getParseResult _ = Nothing
 -- If you need to keep track of error messages, use 'execParserPure' instead.
 {-# DEPRECATED execParserMaybe "Use execParserPure together with getParseResult instead" #-}
 execParserMaybe :: ParserInfo a -> [String] -> Maybe a
-execParserMaybe = customExecParserMaybe (prefs idm)
+execParserMaybe = customExecParserMaybe defaultPrefs
 
 -- | Run a program description with custom preferences in pure code.
 --

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -39,7 +39,7 @@ import Options.Applicative.Help.Types
 #endif
 
 run :: ParserInfo a -> [String] -> ParserResult a
-run = execParserPure (prefs idm)
+run = execParserPure defaultPrefs
 
 assertError :: Show a => ParserResult a
             -> (ParserFailure ParserHelp -> Assertion) -> Assertion
@@ -72,7 +72,7 @@ checkHelpTextWith ecode pprefs name p args = do
     ecode @=? code
 
 checkHelpText :: Show a => String -> ParserInfo a -> [String] -> Assertion
-checkHelpText = checkHelpTextWith ExitSuccess (prefs idm)
+checkHelpText = checkHelpTextWith ExitSuccess defaultPrefs
 
 case_hello :: Assertion
 case_hello = checkHelpText "hello" Hello.opts ["--help"]
@@ -83,7 +83,7 @@ case_modes = checkHelpText "commands" Commands.opts ["--help"]
 case_cmd_header :: Assertion
 case_cmd_header = do
   let i = info (helper <*> Commands.sample) (header "foo")
-  checkHelpTextWith (ExitFailure 1) (prefs idm)
+  checkHelpTextWith (ExitFailure 1) defaultPrefs
                     "commands_header" i ["-zzz"]
   checkHelpTextWith (ExitFailure 1) (prefs showHelpOnError)
                     "commands_header_full" i ["-zzz"]
@@ -179,7 +179,7 @@ case_nested_commands = do
       p2 = subparser (command "b" (info p3 idm))
       p1 = subparser (command "c" (info p2 idm))
       i = info (p1 <**> helper) idm
-  checkHelpTextWith (ExitFailure 1) (prefs idm) "nested" i ["c", "b"]
+  checkHelpTextWith (ExitFailure 1) defaultPrefs "nested" i ["c", "b"]
 
 case_many_args :: Assertion
 case_many_args = do


### PR DESCRIPTION
I was mystified as to how to use `execParserPure` and related functions
to debug a parser, because I couldn't see where there existed a way
to specify default preferences.

Turns out such a way didn't actually exist! This is much preferable
to using `prefs idm` directly, as the word "default" is the first
thing a user will search for, whereas I stumbled on `prefs idm` only
by reading the source.