### PR TITLE
Add standard instances to key types

### DIFF
--- a/Options/Applicative/Help/Chunk.hs
+++ b/Options/Applicative/Help/Chunk.hs
@@ -28,7 +28,7 @@ mappendWith s x y = mconcat [x, s, y]
 -- | The free monoid on a semigroup 'a'.
 newtype Chunk a = Chunk
   { unChunk :: Maybe a }
-  deriving (Eq, Show)
+  deriving (Eq, Read, Show)
 
 instance Functor Chunk where
   fmap f = Chunk . fmap f . unChunk

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -57,7 +57,7 @@ data ParseError
   | InfoMsg String
   | ShowHelpText
   | UnknownError
-  deriving Show
+  deriving (Eq, Read, Show)
 
 instance Monoid ParseError where
   mempty = UnknownError
@@ -91,18 +91,18 @@ data ParserPrefs = ParserPrefs
                                  -- subcommand fails (default: True)
   , prefColumns :: Int           -- ^ number of columns in the terminal, used to
                                  -- format the help page (default: 80)
-  }
+  } deriving (Eq, Read, Show)
 
 data OptName = OptShort !Char
              | OptLong !String
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Read, Show)
 
 -- | Visibility of an option in the help text.
 data OptVisibility
   = Internal          -- ^ does not appear in the help text at all
   | Hidden            -- ^ only visible in the full description
   | Visible           -- ^ visible both in the full and brief descriptions
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Read, Show)
 
 -- | Specification for an individual parser option.
 data OptProperties = OptProperties
@@ -110,13 +110,16 @@ data OptProperties = OptProperties
   , propHelp :: Chunk Doc                 -- ^ help text for this option
   , propMetaVar :: String                 -- ^ metavariable for this option
   , propShowDefault :: Maybe String       -- ^ what to show in the help text as the default
-  }
+  } deriving (Show)
 
 -- | A single option of a parser.
 data Option a = Option
   { optMain :: OptReader a               -- ^ reader for this option
   , optProps :: OptProperties            -- ^ properties of this option
   }
+
+instance Show (Option a) where
+    show opt = "Option {optProps = " ++ show (optProps opt) ++ "}"
 
 instance Functor Option where
   fmap f (Option m p) = Option (fmap f m) p
@@ -297,17 +300,18 @@ type Args = [String]
 data ArgPolicy
   = SkipOpts
   | AllowOpts
-  deriving Eq
+  deriving (Eq, Read, Show)
 
 data OptHelpInfo = OptHelpInfo
   { hinfoMulti :: Bool
-  , hinfoDefault :: Bool }
+  , hinfoDefault :: Bool
+  } deriving (Eq, Read, Show)
 
 data OptTree a
   = Leaf a
   | MultNode [OptTree a]
   | AltNode [OptTree a]
-  deriving Show
+  deriving (Eq, Read, Show)
 
 optVisibility :: Option a -> OptVisibility
 optVisibility = propVisibility . optProps


### PR DESCRIPTION
Several types lack `Show` instances, which makes debugging via `ghci` impossible.