### PR TITLE
Dirty implementation of showing global options in subcommand help

### DIFF
--- a/Options/Applicative/Help/Core.hs
+++ b/Options/Applicative/Help/Core.hs
@@ -10,6 +10,7 @@ module Options.Applicative.Help.Core (
   bodyHelp,
   footerHelp,
   parserHelp,
+  parserHelpWithGlobal,
   parserUsage,
   ) where
 
@@ -93,6 +94,15 @@ footerHelp chunk = ParserHelp mempty mempty mempty mempty chunk
 parserHelp :: ParserPrefs -> Parser a -> ParserHelp
 parserHelp pprefs p = bodyHelp . vsepChunks $
   [ with_title "Available options:" (fullDesc pprefs p)
+  , with_title "Available commands:" (cmdDesc p) ]
+  where
+    with_title :: String -> Chunk Doc -> Chunk Doc
+    with_title title = fmap (string title .$.)
+
+parserHelpWithGlobal :: ParserPrefs -> Parser a -> Parser b -> ParserHelp
+parserHelpWithGlobal pprefs p p' = bodyHelp . vsepChunks $
+  [ with_title "Available options:" (fullDesc pprefs p)
+  , with_title "Global options:" (fullDesc pprefs p')
   , with_title "Available commands:" (cmdDesc p) ]
   where
     with_title :: String -> Chunk Doc -> Chunk Doc

--- a/tests/cabal.err.txt
+++ b/tests/cabal.err.txt
@@ -5,3 +5,8 @@ Available options:
   --enable-tests           Enable compilation of test suites
   -f,--flags FLAGS         Enable the given flag
   -h,--help                Show this help text
+
+Global options:
+  -v,--verbose LEVEL       Set verbosity to LEVEL
+  --version                Print version information
+  -h,--help                Show this help text


### PR DESCRIPTION
Posted this for preliminary review. This tries to resolve https://github.com/pcapriotti/optparse-applicative/issues/138 with as little global changes as possible.

Simple example:

``` haskell
let p = (,) <$> strOption (short 'x' <> help "x option") <*> subparser (command "foo" $ info (helper <*> strOption (short 'y' <> help "y option")) $ progDesc "Foo command")
let f = execParserPure (prefs idm) (info (helper <*> p) fullDesc)
```

```
λ *Options.Applicative > f ["-h"]
Failure (ParserFailure (Usage: <program> -x ARG COMMAND

Available options:
  -h,--help                Show this help text
  -x ARG                   x option

Available commands:
  foo                      Foo command,ExitSuccess,80))

λ *Options.Applicative > f ["foo", "-h"]
Failure (ParserFailure (Usage: <program> foo -y ARG
  Foo command

Available options:
  -h,--help                Show this help text
  -y ARG                   y option

Global options:
  -h,--help                Show this help text
  -x ARG                   x option,ExitSuccess,80))
```

---

I tried to merge options first, but it doesn't make that much sense, taken into account how they are parsed and possible duplicate options
