### PR TITLE
Remove redundant function mappendWith

### DIFF
--- a/Options/Applicative/Help/Chunk.hs
+++ b/Options/Applicative/Help/Chunk.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 module Options.Applicative.Help.Chunk
-  ( mappendWith
-  , Chunk(..)
+  ( Chunk(..)
   , chunked
   , listToChunk
   , (<<+>>)
@@ -21,9 +20,6 @@ import Data.Maybe
 import Data.Monoid
 
 import Options.Applicative.Help.Pretty
-
-mappendWith :: Monoid a => a -> a -> a -> a
-mappendWith s x y = mconcat [x, s, y]
 
 -- | The free monoid on a semigroup 'a'.
 newtype Chunk a = Chunk


### PR DESCRIPTION
Arguments for removal:

* I cannot find any usage of this function on the web.
* Both `a <> b <> c` and `mconcat [a, b, c]` are more intuitive than `mappendWith a b c`.