### PR TITLE
Define Default instance for ParserPrefs

### DIFF
--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -96,6 +96,7 @@ module Options.Applicative.Builder (
   ) where
 
 import Control.Applicative (pure, (<|>))
+import Data.Default.Class (Default(..))
 import Data.Monoid (Monoid (..)
 #if __GLASGOW_HASKELL__ > 702
   , (<>)
@@ -375,14 +376,7 @@ columns :: Int -> PrefsMod
 columns cols = PrefsMod $ \p -> p { prefColumns = cols }
 
 prefs :: PrefsMod -> ParserPrefs
-prefs m = applyPrefsMod m base
-  where
-    base = ParserPrefs
-      { prefMultiSuffix = ""
-      , prefDisambiguate = False
-      , prefShowHelpOnError = False
-      , prefBacktrack = True
-      , prefColumns = 80 }
+prefs m = applyPrefsMod m def
 
 -- convenience shortcuts
 
@@ -392,4 +386,4 @@ idm = mempty
 
 -- | Default preferences.
 defaultPrefs :: ParserPrefs
-defaultPrefs = prefs idm
+defaultPrefs = def

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -45,6 +45,7 @@ import Control.Monad (ap, liftM, MonadPlus, mzero, mplus)
 import Control.Monad.Trans.Except (Except, throwE)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, ask)
+import Data.Default.Class (Default(..))
 import Data.Monoid (Monoid(..))
 import System.Exit (ExitCode(..))
 
@@ -83,6 +84,7 @@ instance Functor ParserInfo where
 -- | Global preferences for a top-level 'Parser'.
 data ParserPrefs = ParserPrefs
   { prefMultiSuffix :: String    -- ^ metavar suffix for multiple options
+                                 -- (default: @""@)
   , prefDisambiguate :: Bool     -- ^ automatically disambiguate abbreviations
                                  -- (default: False)
   , prefShowHelpOnError :: Bool  -- ^ always show help text on parse errors
@@ -92,6 +94,14 @@ data ParserPrefs = ParserPrefs
   , prefColumns :: Int           -- ^ number of columns in the terminal, used to
                                  -- format the help page (default: 80)
   }
+
+instance Default ParserPrefs where
+  def = ParserPrefs
+    { prefMultiSuffix = ""
+    , prefDisambiguate = False
+    , prefShowHelpOnError = False
+    , prefBacktrack = True
+    , prefColumns = 80 }
 
 data OptName = OptShort !Char
              | OptLong !String

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -113,4 +113,5 @@ library
                        transformers >= 0.2 && < 0.5,
                        transformers-compat >= 0.3 && < 0.5,
                        process >= 1.0 && < 1.3,
-                       ansi-wl-pprint >= 0.6 && < 0.7
+                       ansi-wl-pprint >= 0.6 && < 0.7,
+                       data-default-class >= 0.0.1


### PR DESCRIPTION
Given that the documentation explicitely describes the default settings for `ParserPrefs`, I believe it's reasonable "move the default instance into the `ParserPrefs` type".

While this change does add a package dependency, I firmly believe that [data-default-class](https://hackage.haskell.org/package/data-default-class-0.0.1/docs/Data-Default-Class.html) won't see many breaking changes soon…