### PR TITLE
Add Text version of strOption and strArgument

### DIFF
--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -19,6 +19,7 @@ module Options.Applicative.Builder (
   -- creates a parser for an option called \"output\".
   subparser,
   strArgument,
+  txtArgument,
   argument,
   flag,
   flag',
@@ -26,6 +27,7 @@ module Options.Applicative.Builder (
   abortOption,
   infoOption,
   strOption,
+  txtOption,
   option,
   nullOption,
 
@@ -58,6 +60,7 @@ module Options.Applicative.Builder (
   -- | A collection of basic 'Option' readers.
   auto,
   str,
+  txt,
   disabled,
   readerAbort,
   readerError,
@@ -101,6 +104,8 @@ import Data.Monoid (Monoid (..)
   , (<>)
 #endif
   )
+import Data.Text (Text)
+import qualified Data.Text as T
 
 import Options.Applicative.Builder.Completer
 import Options.Applicative.Builder.Internal
@@ -120,6 +125,10 @@ auto = eitherReader $ \arg -> case reads arg of
 -- | String 'Option' reader.
 str :: ReadM String
 str = readerAsk
+
+-- | Text 'Option' reader
+txt :: ReadM Text
+txt = fmap T.pack readerAsk
 
 -- | Null 'Option' reader. All arguments will fail validation.
 disabled :: ReadM a
@@ -225,6 +234,10 @@ argument p (Mod f d g) = mkParser d g (ArgReader rdr)
 strArgument :: Mod ArgumentFields String -> Parser String
 strArgument = argument str
 
+-- | Builder for a 'Text' argument.
+txtArgument :: Mod ArgumentFields Text -> Parser Text
+txtArgument = argument txt
+
 -- | Builder for a flag parser.
 --
 -- A flag that switches from a \"default value\" to an \"active value\" when
@@ -278,6 +291,10 @@ infoOption = abortOption . InfoMsg
 -- | Builder for an option taking a 'String' argument.
 strOption :: Mod OptionFields String -> Parser String
 strOption = option str
+
+-- | Builder for an option taking a 'Text' argument.
+txtOption :: Mod OptionFields Text -> Parser Text
+txtOption = option txt
 
 -- | Same as 'option'.
 {-# DEPRECATED nullOption "Use 'option' instead" #-}

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -113,4 +113,5 @@ library
                        transformers >= 0.2 && < 0.6,
                        transformers-compat >= 0.3 && < 0.6,
                        process >= 1.0 && < 1.5,
-                       ansi-wl-pprint >= 0.6.6 && < 0.7
+                       ansi-wl-pprint >= 0.6.6 && < 0.7,
+                       text >= 1.2.0.4

--- a/tests/optparse-applicative-tests.cabal
+++ b/tests/optparse-applicative-tests.cabal
@@ -37,4 +37,5 @@ executable optparse-applicative-tests
                        tasty >= 0.8 && < 0.11,
                        tasty-hunit >= 0.8 && < 0.10,
                        tasty-quickcheck == 0.8.*,
-                       tasty-th == 0.1.*
+                       tasty-th == 0.1.*,
+                       text >= 1.2.0.4


### PR DESCRIPTION
Adds:

- `txt` a `ReadM` for text, analog to `str`
- `txtOption` and `txtArgument` analog to `strOption` and `strArgument` for String

I had to **add `text` as a dependency**, I am not sure if we need a version bound at all, but I picked the one from the `commercialhaskell/stack` project (arbitrarily).

And for bonus points, here is the effect of adding `text` on the dependency graph, showing that it only adds `text`:
![optparse](https://cloud.githubusercontent.com/assets/591567/9199788/c5ac85ce-4044-11e5-9994-b66a0c571e57.png)

![optparse-with-text](https://cloud.githubusercontent.com/assets/591567/9199744/7dc1bc2a-4044-11e5-9a5a-5a3bd6afcf47.png)
