### PR TITLE
Relax dependency on the process package

### DIFF
--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -1,5 +1,5 @@
 name:                optparse-applicative
-version:             0.11.0.2
+version:             0.11.0.3
 synopsis:            Utilities and combinators for parsing command line options
 description:
     Here is a simple example of an applicative option parser:
@@ -112,5 +112,5 @@ library
   build-depends:       base == 4.*,
                        transformers >= 0.2 && < 0.5,
                        transformers-compat >= 0.3 && < 0.5,
-                       process >= 1.0 && < 1.3,
+                       process >= 1.0 && < 1.4,
                        ansi-wl-pprint >= 0.6 && < 0.7

--- a/tests/optparse-applicative-tests.cabal
+++ b/tests/optparse-applicative-tests.cabal
@@ -32,7 +32,7 @@ executable optparse-applicative-tests
                        QuickCheck >= 2.6 && < 2.8,
                        transformers >= 0.2 && < 0.5,
                        transformers-compat >= 0.3 && < 0.5,
-                       process >= 1.0 && < 1.3,
+                       process >= 1.0 && < 1.4,
                        ansi-wl-pprint >= 0.6 && < 0.7,
                        tasty >= 0.8 && < 0.11,
                        tasty-hunit >= 0.8 && < 0.10,


### PR DESCRIPTION
Version 1.3 of process package has been released and the dependency
process < 1.3 causes conflicts in some cases and can be relaxed.

I verified that the tests build and pass with `process` 1.3.