### PR TITLE
Change the internal separator inside the bash completion script #146.

### DIFF
--- a/Options/Applicative/BashCompletion.hs
+++ b/Options/Applicative/BashCompletion.hs
@@ -78,6 +78,7 @@ bashCompletionScript prog progn = return
   [ "_" ++ progn ++ "()"
   , "{"
   , "    local cmdline"
+  , "    local IFS=$'\n'"
   , "    CMDLINE=(--bash-completion-index $COMP_CWORD)"
   , ""
   , "    for arg in ${COMP_WORDS[@]}; do"


### PR DESCRIPTION
The default separator includes space, which breaks completion on
filenames which have spaces in them. So we set it to '\n'.