### PR TITLE
Feature/enum

### DIFF
--- a/tests/optparse-applicative-tests.cabal
+++ b/tests/optparse-applicative-tests.cabal
@@ -29,7 +29,7 @@ executable optparse-applicative-tests
   ghc-options:         -Wall -fno-warn-orphans
   build-depends:       base == 4.*,
                        HUnit == 1.2.*,
-                       QuickCheck >= 2.6 && < 2.8,
+                       QuickCheck >= 2.6 && < 2.9,
                        transformers >= 0.2 && < 0.5,
                        transformers-compat >= 0.3 && < 0.5,
                        process >= 1.0 && < 1.5,


### PR DESCRIPTION
Hi there, 

I was looking for automatic support for simple ADT (aka Enum), more specially, dataconstructors have to start with a capital letter but in the unix world we usually pass values lowercase.

So this `enum` just does that, you can see it in action here:
http://pastie.org/10687143

We could later improve or add more related functionalities (like outputing the alternatives in the help), but we can start with this simple combinator.

I understand I might have missed something that would allow me to achieve what I want, but I could not find an other way than writing this combinator.

Thanks for this great library.