### PR TITLE
Move help related functionality away from the main workers.

### DIFF
--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -166,11 +166,11 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
         , fmap (indent 2) . infoProgDesc $ i ]
 
     error_help = errorHelp $ case msg of
-      ShowHelpText   -> mempty
-      ErrorMsg m     -> stringChunk m
-      InfoMsg  m     -> stringChunk m
-      MissingError x -> stringChunk "Missing:" <<+>> fold_tree x
-      UnknownError   -> mempty
+      ShowHelpText                -> mempty
+      ErrorMsg m                  -> stringChunk m
+      InfoMsg  m                  -> stringChunk m
+      MissingError (SomeParser x) -> stringChunk "Missing:" <<+>> briefDesc pprefs x
+      UnknownError                -> mempty
 
     base_help :: ParserInfo a -> ParserHelp
     base_help i

--- a/Options/Applicative/Internal.hs
+++ b/Options/Applicative/Internal.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE ExistentialQuantification #-}
 module Options.Applicative.Internal
   ( P
-  , Context(..)
   , MonadP(..)
   , ParseError(..)
 
@@ -69,10 +68,6 @@ instance Monad P where
 instance MonadPlus P where
   mzero = P mzero
   mplus (P x) (P y) = P $ mplus x y
-
-
-data Context
-  = forall a . Context String (ParserInfo a)
 
 contextNames :: [Context] -> [String]
 contextNames ns =

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -27,6 +27,7 @@ module Options.Applicative.Types (
   OptHelpInfo(..),
   OptTree(..),
   ParserHelp(..),
+  SomeParser(..),
 
   fromM,
   oneM,
@@ -57,8 +58,7 @@ data ParseError
   | InfoMsg String
   | ShowHelpText
   | UnknownError
-  | MissingError (OptTree (Chunk Doc))
-  deriving Show
+  | MissingError SomeParser
 
 instance Monoid ParseError where
   mempty = UnknownError
@@ -118,6 +118,8 @@ data Option a = Option
   { optMain :: OptReader a               -- ^ reader for this option
   , optProps :: OptProperties            -- ^ properties of this option
   }
+
+data SomeParser = forall a . SomeParser (Parser a)
 
 instance Show (Option a) where
     show opt = "Option {optProps = " ++ show (optProps opt) ++ "}"

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -122,8 +122,9 @@ data Option a = Option
 
 data SomeParser = forall a . SomeParser (Parser a)
 
-data Context
-  = forall a . Context String (ParserInfo a)
+-- | Subparser context, containing the 'name' of the subparser, and it's parser info.
+--   Used by parserFailure to display relevant usage information when parsing inside a subparser fails.
+data Context = forall a . Context String (ParserInfo a)
 
 instance Show (Option a) where
     show opt = "Option {optProps = " ++ show (optProps opt) ++ "}"

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -28,6 +28,7 @@ module Options.Applicative.Types (
   OptTree(..),
   ParserHelp(..),
   SomeParser(..),
+  Context(..),
 
   fromM,
   oneM,
@@ -120,6 +121,9 @@ data Option a = Option
   }
 
 data SomeParser = forall a . SomeParser (Parser a)
+
+data Context
+  = forall a . Context String (ParserInfo a)
 
 instance Show (Option a) where
     show opt = "Option {optProps = " ++ show (optProps opt) ++ "}"


### PR DESCRIPTION
Some usage text items were moved to common making the 0.12 branch in
order to support `Missing` error messages.
But it wasn't necessary in hindsight, missing options can be made with
a small change to exitP in the P Monad.
So partially this is a revert, regaining good conceptual separation.