### PR TITLE
Fix various 7.10 warnings around Monoid and Applicative.

### DIFF
--- a/Options/Applicative/BashCompletion.hs
+++ b/Options/Applicative/BashCompletion.hs
@@ -7,7 +7,8 @@ module Options.Applicative.BashCompletion
   ( bashCompletionParser
   ) where
 
-import Control.Applicative ((<$>), (<*>), many)
+import Control.Applicative
+import Prelude
 import Data.Foldable (asum)
 import Data.List (isPrefixOf)
 import Data.Maybe (fromMaybe, listToMaybe)

--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -95,12 +95,9 @@ module Options.Applicative.Builder (
   CommandFields
   ) where
 
-import Control.Applicative (pure, (<|>))
-import Data.Monoid (Monoid (..)
-#if __GLASGOW_HASKELL__ > 702
-  , (<>)
-#endif
-  )
+import Control.Applicative
+import Data.Monoid
+import Prelude
 
 import Options.Applicative.Builder.Completer
 import Options.Applicative.Builder.Internal

--- a/Options/Applicative/Builder/Completer.hs
+++ b/Options/Applicative/Builder/Completer.hs
@@ -6,7 +6,8 @@ module Options.Applicative.Builder.Completer
   , bashCompleter
   ) where
 
-import Control.Applicative ((<$>), pure)
+import Control.Applicative
+import Prelude
 import Control.Exception (IOException, try)
 import Data.List (isPrefixOf)
 import System.Process (readProcess)

--- a/Options/Applicative/Builder/Internal.hs
+++ b/Options/Applicative/Builder/Internal.hs
@@ -23,9 +23,10 @@ module Options.Applicative.Builder.Internal (
   internal
   ) where
 
-import Control.Applicative (pure, (<*>), empty, (<|>))
+import Control.Applicative
 import Control.Monad (mplus)
-import Data.Monoid (Monoid(..))
+import Data.Monoid
+import Prelude
 
 import Options.Applicative.Common
 import Options.Applicative.Types

--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -50,13 +50,14 @@ module Options.Applicative.Common (
   optionNames
   ) where
 
-import Control.Applicative (pure, (<*>), (<*), (*>), (<$>), (<|>), (<$))
+import Control.Applicative
 import Control.Monad (guard, mzero, msum, when, liftM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State (StateT(..), get, put, runStateT)
 import Data.List (isPrefixOf)
 import Data.Maybe (maybeToList, isJust)
-import Data.Monoid (Monoid(..))
+import Data.Monoid
+import Prelude
 
 import Options.Applicative.Internal
 import Options.Applicative.Types

--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -21,8 +21,9 @@ module Options.Applicative.Extra (
   CompletionResult(..),
   ) where
 
-import Control.Applicative (pure, (<$>), (<|>), (<**>))
-import Data.Monoid (mempty, mconcat)
+import Control.Applicative
+import Data.Monoid
+import Prelude
 import System.Environment (getArgs, getProgName)
 import System.Exit (exitSuccess, exitWith, ExitCode(..))
 import System.IO (hPutStrLn, stderr)

--- a/Options/Applicative/Help/Chunk.hs
+++ b/Options/Applicative/Help/Chunk.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module Options.Applicative.Help.Chunk
   ( mappendWith
   , Chunk(..)
@@ -19,6 +18,7 @@ import Control.Applicative
 import Control.Monad
 import Data.Maybe
 import Data.Monoid
+import Prelude
 
 import Options.Applicative.Help.Pretty
 

--- a/Options/Applicative/Help/Core.hs
+++ b/Options/Applicative/Help/Core.hs
@@ -16,7 +16,8 @@ module Options.Applicative.Help.Core (
 import Control.Monad (guard)
 import Data.List (sort, intersperse)
 import Data.Maybe (maybeToList, catMaybes)
-import Data.Monoid (mempty, mappend)
+import Data.Monoid
+import Prelude
 
 import Options.Applicative.Common
 import Options.Applicative.Types

--- a/Options/Applicative/Help/Types.hs
+++ b/Options/Applicative/Help/Types.hs
@@ -4,6 +4,7 @@ module Options.Applicative.Help.Types (
   ) where
 
 import Data.Monoid
+import Prelude
 
 import Options.Applicative.Help.Chunk
 import Options.Applicative.Help.Pretty

--- a/Options/Applicative/Internal.hs
+++ b/Options/Applicative/Internal.hs
@@ -27,7 +27,8 @@ module Options.Applicative.Internal
   , disamb
   ) where
 
-import Control.Applicative (Applicative(..), Alternative(..), (<$>))
+import Control.Applicative
+import Prelude
 import Control.Monad (MonadPlus(..), liftM, ap, guard)
 import Control.Monad.Trans.Class (MonadTrans, lift)
 import Control.Monad.Trans.Except

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -42,17 +42,19 @@ module Options.Applicative.Types (
   ) where
 
 import Control.Applicative
-  (Applicative(..), Alternative(..), (<$>), optional)
 import Control.Monad (ap, liftM, MonadPlus, mzero, mplus)
 import Control.Monad.Trans.Except (Except, throwE)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, ask)
-import Data.Monoid (Monoid(..))
+import Data.Monoid
+import Prelude
+
 import System.Exit (ExitCode(..))
 
 import Options.Applicative.Help.Types
 import Options.Applicative.Help.Pretty
 import Options.Applicative.Help.Chunk
+
 
 data ParseError
   = ErrorMsg String


### PR DESCRIPTION
Updated version of this fix using the `import Prelude` solution

https://github.com/pcapriotti/optparse-applicative/pull/149
