### PR TITLE
Add MonadThrow instance for ReadM

### DIFF
--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -43,6 +43,7 @@ module Options.Applicative.Types (
 
 import Control.Applicative
 import Control.Monad (ap, liftM, MonadPlus, mzero, mplus)
+import Control.Monad.Catch (MonadThrow(..))
 import Control.Monad.Trans.Except (Except, throwE)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, ask)
@@ -157,6 +158,9 @@ instance Monad ReadM where
 instance MonadPlus ReadM where
   mzero = ReadM mzero
   mplus (ReadM x) (ReadM y) = ReadM $ mplus x y
+
+instance MonadThrow ReadM where
+  throwM = readerError . show
 
 -- | Return the value being read.
 readerAsk :: ReadM String

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -113,4 +113,5 @@ library
                        transformers >= 0.2 && < 0.6,
                        transformers-compat >= 0.3 && < 0.6,
                        process >= 1.0 && < 1.5,
-                       ansi-wl-pprint >= 0.6.6 && < 0.7
+                       ansi-wl-pprint >= 0.6.6 && < 0.7,
+                       exceptions >= 0.4 && < 0.9

--- a/tests/optparse-applicative-tests.cabal
+++ b/tests/optparse-applicative-tests.cabal
@@ -37,4 +37,5 @@ executable optparse-applicative-tests
                        tasty >= 0.8 && < 0.11,
                        tasty-hunit >= 0.8 && < 0.10,
                        tasty-quickcheck == 0.8.*,
-                       tasty-th == 0.1.*
+                       tasty-th == 0.1.*,
+                       exceptions >= 0.4 && < 0.9


### PR DESCRIPTION
This allows me to e.g. use [`Path.parseAbsDir`](http://hackage.haskell.org/package/path-0.5.7/docs/Path.html#v:parseAbsDir) as an option reader.