### PR TITLE
Basic grouping of subparser commands

### DIFF
--- a/Options/Applicative/BashCompletion.hs
+++ b/Options/Applicative/BashCompletion.hs
@@ -49,7 +49,7 @@ bashCompletionQuery pinfo pprefs ws i _ = case runCompletion compl pprefs of
       OptReader ns _ _ -> return $ show_names ns
       FlagReader ns _  -> return $ show_names ns
       ArgReader rdr    -> run_completer (crCompleter rdr)
-      CmdReader ns _   -> return $ filter_names ns
+      CmdReader _ ns _ -> return $ filter_names ns
 
     show_name :: OptName -> String
     show_name (OptShort c) = '-':[c]

--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -43,6 +43,7 @@ module Options.Applicative.Builder (
   hidden,
   internal,
   command,
+  commandGroup,
   completeWith,
   action,
   completer,
@@ -184,6 +185,11 @@ command :: String -> ParserInfo a -> Mod CommandFields a
 command cmd pinfo = fieldMod $ \p ->
   p { cmdCommands = (cmd, pinfo) : cmdCommands p }
 
+-- | Add a command to a subparser option.
+commandGroup :: String -> Mod CommandFields a
+commandGroup g = fieldMod $ \p ->
+  p { cmdGroup = Just g }
+
 -- | Add a list of possible completion values.
 completeWith :: HasCompleter f => [String] -> Mod f a
 completeWith xs = completer (listCompleter xs)
@@ -210,7 +216,8 @@ subparser :: Mod CommandFields a -> Parser a
 subparser m = mkParser d g rdr
   where
     Mod _ d g = metavar "COMMAND" `mappend` m
-    rdr = uncurry CmdReader (mkCommand m)
+    (groupName, cmds, subs) = mkCommand m
+    rdr = CmdReader groupName cmds subs
 
 -- | Builder for an argument parser.
 argument :: ReadM a -> Mod ArgumentFields a -> Parser a

--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -185,7 +185,7 @@ command :: String -> ParserInfo a -> Mod CommandFields a
 command cmd pinfo = fieldMod $ \p ->
   p { cmdCommands = (cmd, pinfo) : cmdCommands p }
 
--- | Add a command to a subparser option.
+-- | Add a description to a group of commands.
 commandGroup :: String -> Mod CommandFields a
 commandGroup g = fieldMod $ \p ->
   p { cmdGroup = Just g }

--- a/Options/Applicative/Builder/Internal.hs
+++ b/Options/Applicative/Builder/Internal.hs
@@ -41,7 +41,8 @@ data FlagFields a = FlagFields
   , flagActive :: a }
 
 data CommandFields a = CommandFields
-  { cmdCommands :: [(String, ParserInfo a)] }
+  { cmdCommands :: [(String, ParserInfo a)]
+  , cmdGroup :: Maybe String }
 
 data ArgumentFields a = ArgumentFields
   { argCompleter :: Completer }
@@ -140,11 +141,11 @@ baseProps = OptProperties
   , propHelp = mempty
   , propShowDefault = Nothing }
 
-mkCommand :: Mod CommandFields a -> ([String], String -> Maybe (ParserInfo a))
-mkCommand m = (map fst cmds, (`lookup` cmds))
+mkCommand :: Mod CommandFields a -> (Maybe String, [String], String -> Maybe (ParserInfo a))
+mkCommand m = (group, map fst cmds, (`lookup` cmds))
   where
     Mod f _ _ = m
-    CommandFields cmds = f (CommandFields [])
+    CommandFields cmds group = f (CommandFields [] Nothing)
 
 mkParser :: DefaultProp a
          -> (OptProperties -> OptProperties)

--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -95,7 +95,7 @@ argMatches opt arg = case opt of
   ArgReader rdr -> Just $ do
     result <- lift $ runReadM (crReader rdr) arg
     return result
-  CmdReader _ f ->
+  CmdReader _ _ f ->
     flip fmap (f arg) $ \subp -> StateT $ \args -> do
       prefs <- getPrefs
       let runSubparser

--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -52,8 +52,8 @@ hsubparser :: Mod CommandFields a -> Parser a
 hsubparser m = mkParser d g rdr
   where
     Mod _ d g = metavar "COMMAND" `mappend` m
-    (cmds, subs) = mkCommand m
-    rdr = CmdReader cmds (fmap add_helper . subs)
+    (groupName, cmds, subs) = mkCommand m
+    rdr = CmdReader groupName cmds (fmap add_helper . subs)
     add_helper pinfo = pinfo
       { infoParser = infoParser pinfo <**> helper }
 

--- a/Options/Applicative/Help/Core.hs
+++ b/Options/Applicative/Help/Core.hs
@@ -14,12 +14,12 @@ module Options.Applicative.Help.Core (
   ) where
 
 import Control.Applicative
-import Prelude
 import Control.Monad (guard)
 import Data.Function (on)
 import Data.List (sort, intersperse, groupBy)
 import Data.Maybe (maybeToList, catMaybes, fromMaybe)
-import Data.Monoid (mempty, mappend)
+import Data.Monoid
+import Prelude
 
 import Options.Applicative.Common
 import Options.Applicative.Types

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -188,13 +188,14 @@ data OptReader a
   = OptReader [OptName] (CReader a) ParseError          -- ^ option reader
   | FlagReader [OptName] !a                             -- ^ flag reader
   | ArgReader (CReader a)                               -- ^ argument reader
-  | CmdReader [String] (String -> Maybe (ParserInfo a)) -- ^ command reader
+  | CmdReader (Maybe String)
+              [String] (String -> Maybe (ParserInfo a)) -- ^ command reader
 
 instance Functor OptReader where
   fmap f (OptReader ns cr e) = OptReader ns (fmap f cr) e
   fmap f (FlagReader ns x) = FlagReader ns (f x)
   fmap f (ArgReader cr) = ArgReader (fmap f cr)
-  fmap f (CmdReader cs g) = CmdReader cs ((fmap . fmap) f . g)
+  fmap f (CmdReader n cs g) = CmdReader n cs ((fmap . fmap) f . g)
 
 -- | A @Parser a@ is an option parser returning a value of type 'a'.
 data Parser a

--- a/tests/Examples/Commands.hs
+++ b/tests/Examples/Commands.hs
@@ -27,6 +27,16 @@ sample = subparser
          (info (pure Goodbye)
                (progDesc "Say goodbye"))
        )
+      <|> subparser
+       ( command "bonjour"
+         (info hello
+               (progDesc "Print greeting"))
+      <> command "au-revoir"
+         (info (pure Goodbye)
+               (progDesc "Say goodbye"))
+      <> commandGroup "French commands:"
+      <> hidden
+       )
 
 run :: Sample -> IO ()
 run (Hello targets) = putStrLn $ "Hello, " ++ intercalate ", " targets ++ "!"

--- a/tests/commands.err.txt
+++ b/tests/commands.err.txt
@@ -6,3 +6,7 @@ Available options:
 Available commands:
   hello                    Print greeting
   goodbye                  Say goodbye
+
+French commands:
+  bonjour                  Print greeting
+  au-revoir                Say goodbye

--- a/tests/commands_header_full.err.txt
+++ b/tests/commands_header_full.err.txt
@@ -10,3 +10,7 @@ Available options:
 Available commands:
   hello                    Print greeting
   goodbye                  Say goodbye
+
+French commands:
+  bonjour                  Print greeting
+  au-revoir                Say goodbye


### PR DESCRIPTION
This exposes a new modifier such that groups of commands can have their own textual description, such as Dangerous commands:, or "Infrequent commands:".