### PR TITLE
Allow one to override metavar in hsubparser as well

### DIFF
--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -51,7 +51,7 @@ helper = abortOption ShowHelpText $ mconcat
 hsubparser :: Mod CommandFields a -> Parser a
 hsubparser m = mkParser d g rdr
   where
-    Mod _ d g = m `mappend` metavar "COMMAND"
+    Mod _ d g = metavar "COMMAND" `mappend` m
     (cmds, subs) = mkCommand m
     rdr = CmdReader cmds (fmap add_helper . subs)
     add_helper pinfo = pinfo


### PR DESCRIPTION
Allows one to override the metavar for hsubparser as well.
This is a surprisingly old bug which was fixed for subparser 3 years ago.