### PR TITLE
Don't allow options after '--' if there are no arguments

### DIFF
--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -193,10 +193,8 @@ stepParser :: MonadP m => ParserPrefs -> ArgPolicy -> String
 stepParser pprefs SkipOpts arg p = case parseWord arg of
   Just w -> searchOpt pprefs w p
   Nothing -> searchArg arg p
-stepParser pprefs AllowOpts arg p = msum
-  [ searchArg arg p
-  , do w <- hoistMaybe (parseWord arg)
-       searchOpt pprefs w p ]
+stepParser _ AllowOpts arg p =
+  searchArg arg p
 
 -- | Apply a 'Parser' to a command line, and return a result and leftover
 -- arguments.  This function returns an error if any parsing error occurs, or

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -314,9 +314,13 @@ instance Monad ParserResult where
 
 type Args = [String]
 
+-- | Policy for how to handle options within the parse
 data ArgPolicy
-  = SkipOpts
-  | AllowOpts
+  = SkipOpts  -- ^ Inputs beginning with `-` or `--` are treated
+              --   as options or flags, and can be mixed with arguments.
+  | AllowOpts -- ^ All input is treated as positional arguments.
+              --   Used after a bare `--` input, and also with
+              --   `noIntersperse` policy.
   deriving (Eq, Show)
 
 data OptHelpInfo = OptHelpInfo


### PR DESCRIPTION
Related to #211
Treating arguments after a '--' if there's no arguments left to parse as options could lead to anomalous behaviour in some cases.