### PR TITLE
Rewrite str, eitherReader and maybeReader to be polymorphic over IsSt…

### DIFF
--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -95,6 +95,7 @@ test-suite optparse-applicative-tests
                        tests
 
   build-depends:       base
+                     , bytestring                      == 0.10.*
                      , optparse-applicative
                      , QuickCheck                      >= 2.8 && < 2.11
 


### PR DESCRIPTION
…ring.

This has significant benefits, in that it covers off Text and ByteString
readers for free (and without dependencies) and works pretty seamlessly
with Attoparsec parsers.

May cause breakages if people are using str for type inference.
In that case, adding type signatures should fix the problem.
