### PR TITLE
Fix noIntersperse behaviour, and add a new policy

### DIFF
--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -72,6 +72,7 @@ module Options.Applicative.Builder (
   progDescDoc,
   failureCode,
   noIntersperse,
+  forwardOptions,
   info,
 
   -- * Builder for 'ParserPrefs'
@@ -371,9 +372,22 @@ progDescDoc doc = InfoMod $ \i -> i { infoProgDesc = Chunk doc }
 failureCode :: Int -> InfoMod a
 failureCode n = InfoMod $ \i -> i { infoFailureCode = n }
 
--- | Disable parsing of regular options after arguments
+-- | Disable parsing of regular options after arguments. After a positional
+--   argument is parsed, all remaining options and arguments will be treated
+--   as a positional arguments. Not recommended in general as users often
+--   expect to be able to freely intersperse regular options and flags within
+--   command line options.
 noIntersperse :: InfoMod a
-noIntersperse = InfoMod $ \p -> p { infoIntersperse = False }
+noIntersperse = InfoMod $ \p -> p { infoPolicy = NoInterspersePolicy }
+
+-- | Intersperse matched options and arguments normally, but allow unmatched
+--   options to be treated as positional arguments.
+--   This is sometimes useful if one is wrapping a third party cli tool and
+--   needs to pass options through, while also providing a handful of their
+--   own options. Not recommended in general as typos by the user may not
+--   yield a parse error and cause confusion.
+forwardOptions :: InfoMod a
+forwardOptions = InfoMod $ \p -> p { infoPolicy = DefaultPositionalPolicy }
 
 -- | Create a 'ParserInfo' given a 'Parser' and a modifier.
 info :: Parser a -> InfoMod a -> ParserInfo a
@@ -386,7 +400,7 @@ info parser m = applyInfoMod m base
       , infoHeader = mempty
       , infoFooter = mempty
       , infoFailureCode = 1
-      , infoIntersperse = True }
+      , infoPolicy = InterspersePolicy }
 
 newtype PrefsMod = PrefsMod
   { applyPrefsMod :: ParserPrefs -> ParserPrefs }

--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -378,7 +378,7 @@ failureCode n = InfoMod $ \i -> i { infoFailureCode = n }
 --   expect to be able to freely intersperse regular options and flags within
 --   command line options.
 noIntersperse :: InfoMod a
-noIntersperse = InfoMod $ \p -> p { infoPolicy = NoInterspersePolicy }
+noIntersperse = InfoMod $ \p -> p { infoPolicy = NoIntersperse }
 
 -- | Intersperse matched options and arguments normally, but allow unmatched
 --   options to be treated as positional arguments.
@@ -387,7 +387,7 @@ noIntersperse = InfoMod $ \p -> p { infoPolicy = NoInterspersePolicy }
 --   own options. Not recommended in general as typos by the user may not
 --   yield a parse error and cause confusion.
 forwardOptions :: InfoMod a
-forwardOptions = InfoMod $ \p -> p { infoPolicy = DefaultPositionalPolicy }
+forwardOptions = InfoMod $ \p -> p { infoPolicy = ForwardOptions }
 
 -- | Create a 'ParserInfo' given a 'Parser' and a modifier.
 info :: Parser a -> InfoMod a -> ParserInfo a
@@ -400,7 +400,7 @@ info parser m = applyInfoMod m base
       , infoHeader = mempty
       , infoFooter = mempty
       , infoFailureCode = 1
-      , infoPolicy = InterspersePolicy }
+      , infoPolicy = Intersperse }
 
 newtype PrefsMod = PrefsMod
   { applyPrefsMod :: ParserPrefs -> ParserPrefs }

--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -179,9 +179,9 @@ searchArg arg = searchParser $ \opt -> do
 
 stepParser :: MonadP m => ParserPrefs -> ArgPolicy -> String
            -> Parser a -> NondetT (StateT Args m) (Parser a)
-stepParser _ OnlyPositionalPolicy arg p =
+stepParser _ AllPositionals arg p =
   searchArg arg p
-stepParser pprefs DefaultPositionalPolicy arg p = case parseWord arg of
+stepParser pprefs ForwardOptions arg p = case parseWord arg of
   Just w -> searchOpt pprefs w p <|> searchArg arg p
   Nothing -> searchArg arg p
 stepParser pprefs _ arg p = case parseWord arg of
@@ -193,8 +193,8 @@ stepParser pprefs _ arg p = case parseWord arg of
 -- arguments.  This function returns an error if any parsing error occurs, or
 -- if any options are missing and don't have a default value.
 runParser :: MonadP m => ArgPolicy -> IsCmdStart -> Parser a -> Args -> m (a, Args)
-runParser policy _ p ("--" : argt) | policy /= OnlyPositionalPolicy
-                                   = runParser OnlyPositionalPolicy CmdCont p argt
+runParser policy _ p ("--" : argt) | policy /= AllPositionals
+                                   = runParser AllPositionals CmdCont p argt
 runParser policy isCmdStart p args = case args of
   [] -> exitP isCmdStart p result
   (arg : argt) -> do
@@ -210,8 +210,8 @@ runParser policy isCmdStart p args = case args of
                            $ stepParser prefs policy arg p
 
     newPolicy a = case policy of
-      NoInterspersePolicy -> if isJust (parseWord a) then NoInterspersePolicy else OnlyPositionalPolicy
-      x                   -> x
+      NoIntersperse -> if isJust (parseWord a) then NoIntersperse else AllPositionals
+      x             -> x
 
 parseError :: MonadP m => String -> m a
 parseError arg = errorP . ErrorMsg $ msg

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -84,8 +84,8 @@ data ParserInfo a = ParserInfo
   , infoHeader :: Chunk Doc   -- ^ header of the full parser description
   , infoFooter :: Chunk Doc   -- ^ footer of the full parser description
   , infoFailureCode :: Int    -- ^ exit code for a parser failure
-  , infoIntersperse :: Bool   -- ^ allow regular options and flags to occur
-                              -- after arguments (default: True)
+  , infoPolicy :: ArgPolicy   -- ^ allow regular options and flags to occur
+                              -- after arguments (default: InterspersePolicy)
   }
 
 instance Functor ParserInfo where
@@ -319,12 +319,28 @@ type Args = [String]
 
 -- | Policy for how to handle options within the parse
 data ArgPolicy
-  = SkipOpts  -- ^ Inputs beginning with `-` or `--` are treated
-              --   as options or flags, and can be mixed with arguments.
-  | AllowOpts -- ^ All input is treated as positional arguments.
-              --   Used after a bare `--` input, and also with
-              --   `noIntersperse` policy.
-  deriving (Eq, Show)
+  = InterspersePolicy
+  -- ^ The default policy, options and arguments can
+  --   be interspersed.
+  --   A `--` option can be passed to ensure all following
+  --   commands are treated as arguments.
+  | NoInterspersePolicy
+  -- ^ Options must all come before arguments, once a
+  --   single option is parsed, all remaining arguments
+  --   are treated as positionals.
+  --   A `--` option can be passed if the first positional
+  --   one needs starts with `-`.
+  | OnlyPositionalPolicy
+  -- ^ No options are parsed at all, all arguments are
+  --   treated as positionals.
+  --   Is the policy after `--` is used.
+  | DefaultPositionalPolicy
+  -- ^ Options and arguments can be interspersed, but if
+  --   a given option is not found, it is treated as a
+  --   positional argument. This is sometimes useful if
+  --   one is passing through most options to another tool,
+  --   but are supplying one or of their own modifiers.
+  deriving (Eq, Ord, Show)
 
 data OptHelpInfo = OptHelpInfo
   { hinfoMulti :: Bool

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -326,20 +326,20 @@ data ArgPolicy
   --   commands are treated as arguments.
   | NoInterspersePolicy
   -- ^ Options must all come before arguments, once a
-  --   single option is parsed, all remaining arguments
-  --   are treated as positionals.
+  --   single positional argument or subcommand is parsed,
+  --   all remaining arguments are treated as positionals.
   --   A `--` option can be passed if the first positional
   --   one needs starts with `-`.
   | OnlyPositionalPolicy
   -- ^ No options are parsed at all, all arguments are
   --   treated as positionals.
-  --   Is the policy after `--` is used.
+  --   Is the policy used after `--` is encountered.
   | DefaultPositionalPolicy
   -- ^ Options and arguments can be interspersed, but if
   --   a given option is not found, it is treated as a
   --   positional argument. This is sometimes useful if
   --   one is passing through most options to another tool,
-  --   but are supplying one or of their own modifiers.
+  --   but are supplying just a few of their own options.
   deriving (Eq, Ord, Show)
 
 data OptHelpInfo = OptHelpInfo

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -319,22 +319,22 @@ type Args = [String]
 
 -- | Policy for how to handle options within the parse
 data ArgPolicy
-  = InterspersePolicy
+  = Intersperse
   -- ^ The default policy, options and arguments can
   --   be interspersed.
   --   A `--` option can be passed to ensure all following
   --   commands are treated as arguments.
-  | NoInterspersePolicy
+  | NoIntersperse
   -- ^ Options must all come before arguments, once a
   --   single positional argument or subcommand is parsed,
   --   all remaining arguments are treated as positionals.
   --   A `--` option can be passed if the first positional
   --   one needs starts with `-`.
-  | OnlyPositionalPolicy
+  | AllPositionals
   -- ^ No options are parsed at all, all arguments are
   --   treated as positionals.
   --   Is the policy used after `--` is encountered.
-  | DefaultPositionalPolicy
+  | ForwardOptions
   -- ^ Options and arguments can be interspersed, but if
   --   a given option is not found, it is treated as a
   --   positional argument. This is sometimes useful if

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -404,10 +404,32 @@ prop_intersperse_2 = once $
              ( info (many (argument str (metavar "ARGS")))
                     idm ) )
       i = info p idm
-      result1 = run i ["run", "-x", "foo"]
-      result2 = run i ["test", "-x", "bar"]
-  in conjoin [ assertResult result1 $ \args -> ["-x", "foo"] === args
+      result1 = run i ["run", "foo", "-x"]
+      result2 = run i ["test", "bar", "-x"]
+  in conjoin [ assertResult result1 $ \args -> ["foo", "-x"] === args
              , assertError result2 $ \_ -> property succeeded ]
+
+prop_intersperse_3 :: Property
+prop_intersperse_3 = once $
+  let p = (,,) <$> switch ( long "foo" )
+               <*> strArgument ( metavar "FILE" )
+               <*> many ( strArgument ( metavar "ARGS..." ) )
+      i = info p noIntersperse
+      result = run i ["--foo", "myfile", "-a", "-b", "-c"]
+  in assertResult result $ \(b,f,as) ->
+     conjoin [ ["-a", "-b", "-c"] === as
+             , True               === b
+             , "myfile"           === f ]
+
+prop_forward_options :: Property
+prop_forward_options = once $
+  let p = (,) <$> switch ( long "foo" )
+              <*> many ( strArgument ( metavar "ARGS..." ) )
+      i = info p forwardOptions
+      result = run i ["--fo", "--foo", "myfile"]
+  in assertResult result $ \(b,a) ->
+     conjoin [ True               === b
+             , ["--fo", "myfile"] === a ]
 
 prop_issue_52 :: Property
 prop_issue_52 = once $


### PR DESCRIPTION
noInterperse was not allowing any options to occur
before arguments, and wasn't behaving as its namesake
in other parsing libraries.

Add a new policy (which is potentially useful for
applications wrapping other cli tools) allowing the
command (or subcommand) to collect all unknown options
and arguments as positionals to be passed to the
command line.
