### PR TITLE
Add suggestions for typos

### DIFF
--- a/Options/Applicative/BashCompletion.hs
+++ b/Options/Applicative/BashCompletion.hs
@@ -40,16 +40,30 @@ bashCompletionQuery pinfo pprefs ws i _ = case runCompletion compl pprefs of
   Just (Right c)             -> run_completer c
   _                          -> return []
   where
-    list_options =
-        fmap concat
+    list_options
+      = fmap concat
       . sequence
-      . mapParser (const opt_completions)
+      . mapParser opt_completions
 
-    opt_completions opt = case optMain opt of
+    --
+    -- Prior to 0.14 there was a subtle bug which would
+    -- mean that completions from positional arguments
+    -- further into the parse would be shown.
+    --
+    -- We therefore now check to see that
+    -- hinfoUnreachableArgs is off before running the
+    -- completion for position arguments.
+    opt_completions hinfo opt = case optMain opt of
       OptReader ns _ _ -> return $ show_names ns
       FlagReader ns _  -> return $ show_names ns
-      ArgReader rdr    -> run_completer (crCompleter rdr)
-      CmdReader _ ns _ -> return $ filter_names ns
+      ArgReader rdr     | hinfoUnreachableArgs hinfo
+                       -> return []
+                        | otherwise
+                       -> run_completer (crCompleter rdr)
+      CmdReader _ ns _  | hinfoUnreachableArgs hinfo
+                       -> return []
+                        | otherwise
+                       -> return $ filter_names ns
 
     show_name :: OptName -> String
     show_name (OptShort c) = '-':[c]

--- a/Options/Applicative/BashCompletion.hs
+++ b/Options/Applicative/BashCompletion.hs
@@ -92,8 +92,8 @@ bashCompletionScript :: String -> String -> IO [String]
 bashCompletionScript prog progn = return
   [ "_" ++ progn ++ "()"
   , "{"
-  , "    local cmdline"
-  , "    local IFS=$'\n'"
+  , "    local CMDLINE"
+  , "    local IFS=$'\\n'"
   , "    CMDLINE=(--bash-completion-index $COMP_CWORD)"
   , ""
   , "    for arg in ${COMP_WORDS[@]}; do"

--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -164,10 +164,12 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
     with_context c@(Context _ i:_) _ f = f (contextNames c) i
 
     usage_help progn names i = case msg of
-      InfoMsg _ -> mempty
-      _         -> usageHelp $ vcatChunks
-        [ pure . parserUsage pprefs (infoParser i) . unwords $ progn : names
-        , fmap (indent 2) . infoProgDesc $ i ]
+      InfoMsg _
+        -> mempty
+      _
+        -> usageHelp $ vcatChunks
+          [ pure . parserUsage pprefs (infoParser i) . unwords $ progn : names
+          , fmap (indent 2) . infoProgDesc $ i ]
 
     error_help = errorHelp $ case msg of
       ShowHelpText
@@ -192,7 +194,6 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
             --
             -- This gives us the same error we have always
             -- reported
-            --
             msg' = case arg of
               ('-':_) -> "Invalid option `" ++ arg ++ "'"
               _       -> "Invalid argument `" ++ arg ++ "'"
@@ -210,7 +211,6 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
         -- We can make a good help suggestion here if we do
         -- a levenstein distance between all possible suggestions
         -- and the supplied option or argument.
-        --
         -> suggestions
           where
             --

--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -33,6 +33,7 @@ import Options.Applicative.Builder hiding (briefDesc)
 import Options.Applicative.Builder.Internal
 import Options.Applicative.Common
 import Options.Applicative.Help
+import Options.Applicative.Help.Levenshtein ( editDistance )
 
 import Options.Applicative.Internal
 import Options.Applicative.Types
@@ -147,11 +148,12 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
   in (h, exit_code, prefColumns pprefs)
   where
     exit_code = case msg of
-      ErrorMsg _       -> ExitFailure (infoFailureCode pinfo)
-      UnknownError     -> ExitFailure (infoFailureCode pinfo)
-      MissingError _ _ -> ExitFailure (infoFailureCode pinfo)
-      ShowHelpText     -> ExitSuccess
-      InfoMsg  _       -> ExitSuccess
+      ErrorMsg {}        -> ExitFailure (infoFailureCode pinfo)
+      UnknownError       -> ExitFailure (infoFailureCode pinfo)
+      MissingError {}    -> ExitFailure (infoFailureCode pinfo)
+      UnexpectedError {} -> ExitFailure (infoFailureCode pinfo)
+      ShowHelpText       -> ExitSuccess
+      InfoMsg {}         -> ExitSuccess
 
     with_context :: [Context]
                  -> ParserInfo a
@@ -167,13 +169,89 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
         , fmap (indent 2) . infoProgDesc $ i ]
 
     error_help = errorHelp $ case msg of
-      ShowHelpText                  -> mempty
-      ErrorMsg m                    -> stringChunk m
-      InfoMsg  m                    -> stringChunk m
-      MissingError CmdStart _        | prefShowHelpOnEmpty pprefs
-                                    -> mempty
-      MissingError _ (SomeParser x) -> stringChunk "Missing:" <<+>> missingDesc pprefs x
-      UnknownError                  -> mempty
+      ShowHelpText
+        -> mempty
+
+      ErrorMsg m
+        -> stringChunk m
+
+      InfoMsg  m
+        -> stringChunk m
+
+      MissingError CmdStart _
+        | prefShowHelpOnEmpty pprefs
+        -> mempty
+
+      MissingError _ (SomeParser x)
+        -> stringChunk "Missing:" <<+>> missingDesc pprefs x
+
+      UnexpectedError arg (SomeParser x)
+        --
+        -- We have an unexpected argument and the parser which
+        -- it's running over.
+        --
+        -- We can make a good help suggestion here if we do
+        -- a levenstein distance between all possible suggestions
+        -- and the supplied option or argument.
+        --
+        -> vsepChunks [stringChunk msg', suggestions]
+          where
+            --
+            -- This gives us the same error we have always
+            -- reported
+            msg' = case arg of
+              ('-':_) -> "Invalid option `" ++ arg ++ "'"
+              _       -> "Invalid argument `" ++ arg ++ "'"
+
+            --
+            -- Not using chunked here, as we don't want to
+            -- show "Did you mean" if there's nothing there
+            -- to show
+            suggestions = (.$.) <$> prose
+                                <*> (indent 4 <$> (vcatChunks . fmap stringChunk $ good ))
+
+            --
+            -- We won't worry about the 0 case, it won't be
+            -- shown anyway.
+            prose       = if length good < 2
+                            then stringChunk "Did you mean this?"
+                            else stringChunk "Did you mean one of these?"
+            --
+            -- Suggestions we will show, they're close enough
+            -- to what the user wrote
+            good        = filter (isClose arg) possibles
+
+            --
+            -- Bit of an arbitrary decision here.
+            -- Edit distances of 1 or 2 will give hints
+            isClose a b = editDistance a b < 3
+
+            --
+            -- Similar to how bash completion works.
+            -- We map over the parser and get the names
+            -- ( no IO here though, unlike for completers )
+            possibles   = concat $ mapParser opt_completions x
+
+            --
+            -- Look at the option and give back the possible
+            -- things the user could type. If it's a command
+            -- reader also ensure that it can be immediately
+            -- reachable from where the error was given.
+            opt_completions hinfo opt = case optMain opt of
+              OptReader ns _ _ -> fmap show_name ns
+              FlagReader ns _  -> fmap show_name ns
+              ArgReader _      -> []
+              CmdReader _ ns _  | hinfoUnreachableArgs hinfo
+                               -> []
+                                | otherwise
+                               -> ns
+
+            show_name :: OptName -> String
+            show_name (OptShort c) = '-':[c]
+            show_name (OptLong l) = "--" ++ l
+
+      UnknownError
+        -> mempty
 
     base_help :: ParserInfo a -> ParserHelp
     base_help i
@@ -187,7 +265,7 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
 
     show_full_help = case msg of
       ShowHelpText             -> True
-      MissingError CmdStart  _ | prefShowHelpOnEmpty pprefs
+      MissingError CmdStart  _  | prefShowHelpOnEmpty pprefs
                                -> True
       _                        -> prefShowHelpOnError pprefs
 

--- a/Options/Applicative/Help/Core.hs
+++ b/Options/Applicative/Help/Core.hs
@@ -7,6 +7,7 @@ module Options.Applicative.Help.Core (
   ParserHelp(..),
   errorHelp,
   headerHelp,
+  suggestionsHelp,
   usageHelp,
   bodyHelp,
   footerHelp,
@@ -131,19 +132,22 @@ fullDesc pprefs = tabulate . catMaybes . mapParser doc
       , descSurround = False }
 
 errorHelp :: Chunk Doc -> ParserHelp
-errorHelp chunk = ParserHelp chunk mempty mempty mempty mempty
+errorHelp chunk = mempty { helpError = chunk }
 
 headerHelp :: Chunk Doc -> ParserHelp
-headerHelp chunk = ParserHelp mempty chunk mempty mempty mempty
+headerHelp chunk = mempty { helpHeader = chunk }
+
+suggestionsHelp :: Chunk Doc -> ParserHelp
+suggestionsHelp chunk = mempty { helpSuggestions = chunk }
 
 usageHelp :: Chunk Doc -> ParserHelp
-usageHelp chunk = ParserHelp mempty mempty chunk mempty mempty
+usageHelp chunk = mempty { helpUsage = chunk }
 
 bodyHelp :: Chunk Doc -> ParserHelp
-bodyHelp chunk = ParserHelp mempty mempty mempty chunk mempty
+bodyHelp chunk = mempty { helpBody = chunk }
 
 footerHelp :: Chunk Doc -> ParserHelp
-footerHelp chunk = ParserHelp mempty mempty mempty mempty chunk
+footerHelp chunk = mempty { helpFooter = chunk }
 
 -- | Generate the help text for a program.
 parserHelp :: ParserPrefs -> Parser a -> ParserHelp

--- a/Options/Applicative/Help/Levenshtein.hs
+++ b/Options/Applicative/Help/Levenshtein.hs
@@ -25,30 +25,48 @@ module Options.Applicative.Help.Levenshtein (
 --   As there are a few ugly partial function calls
 --   there's property tests to ensure it doesn't
 --   crash :/ and obeys the laws.
---
 editDistance :: Eq a => [a] -> [a] -> Int
-editDistance a b
-    = last (if lab == 0 then mainDiag
-            else if lab > 0 then lowers !! (lab - 1)
-                 else {- < 0 -}  uppers !! (-1 - lab))
-    where mainDiag = oneDiag a b (head uppers) (-1 : head lowers)
-          uppers = eachDiag a b (mainDiag : uppers) -- upper diagonals
-          lowers = eachDiag b a (mainDiag : lowers) -- lower diagonals
-          eachDiag _ [] _ = []
-          eachDiag _ _ [] = []
-          eachDiag a' (_:bs) (lastDiag:diags) = oneDiag a' bs nextDiag lastDiag : eachDiag a' bs diags
-              where nextDiag = head (tail diags)
-          oneDiag a' b' diagAbove diagBelow = thisdiag
-              where doDiag [] _ _ _ _ = []
-                    doDiag _ [] _ _ _ = []
-                    -- Check for a transposition
-                    doDiag (ach:ach':as) (bch:bch':bs) nw n w
-                      | ach' == bch && ach == bch'
-                      = nw : (doDiag (ach':as) (bch':bs) nw (tail n) (tail w))
-                    -- Usual case
-                    doDiag (ach:as) (bch:bs) nw n w = me : (doDiag as bs me (tail n) (tail w))
-                        where me = if ach == bch then nw else 1 + min3 (head w) nw (head n)
-                    firstelt = 1 + head diagBelow
-                    thisdiag = firstelt : doDiag a' b' firstelt diagAbove (tail diagBelow)
-          lab = length a - length b
-          min3 x y z = if x < y then x else min y z
+editDistance a b = last $
+  case () of
+    _ | lab == 0
+     -> mainDiag
+      | lab > 0
+     -> lowers !! (lab - 1)
+      | otherwise
+     -> uppers !! (-1 - lab)
+  where
+    mainDiag = oneDiag a b (head uppers) (-1 : head lowers)
+    uppers = eachDiag a b (mainDiag : uppers) -- upper diagonals
+    lowers = eachDiag b a (mainDiag : lowers) -- lower diagonals
+    eachDiag _ [] _ = []
+    eachDiag _ _ [] = []
+    eachDiag a' (_:bs) (lastDiag:diags) =
+      oneDiag a' bs nextDiag lastDiag : eachDiag a' bs diags
+      where
+        nextDiag = head (tail diags)
+    oneDiag a' b' diagAbove diagBelow = thisdiag
+      where
+        doDiag [] _ _ _ _ = []
+        doDiag _ [] _ _ _ = []
+        -- Check for a transposition
+        -- We don't add anything to nw here, the next character
+        -- will be different however and the transposition
+        -- will have an edit distance of 1.
+        doDiag (ach:ach':as) (bch:bch':bs) nw n w
+          | ach' == bch && ach == bch'
+          = nw : (doDiag (ach' : as) (bch' : bs) nw (tail n) (tail w))
+        -- Standard case
+        doDiag (ach:as) (bch:bs) nw n w =
+          me : (doDiag as bs me (tail n) (tail w))
+          where
+            me =
+              if ach == bch
+                then nw
+                else 1 + min3 (head w) nw (head n)
+        firstelt = 1 + head diagBelow
+        thisdiag = firstelt : doDiag a' b' firstelt diagAbove (tail diagBelow)
+    lab = length a - length b
+    min3 x y z =
+      if x < y
+        then x
+        else min y z

--- a/Options/Applicative/Help/Levenshtein.hs
+++ b/Options/Applicative/Help/Levenshtein.hs
@@ -1,0 +1,54 @@
+module Options.Applicative.Help.Levenshtein (
+    editDistance
+  ) where
+
+-- | Calculate the Damerau-Levenshtein edit distance
+--   between two lists (strings).
+--
+--   Optparse can't really take on any dependencies
+--   so we're bringing it in here.
+--
+--   This is modified from
+--   https://wiki.haskell.org/Edit_distance
+--   and is originally from Lloyd Allison's paper
+--   "Lazy Dynamic-Programming can be Eager"
+--
+--   It's been changed though from Levenshtein to
+--   Damerau-Levenshtein, which treats transposition
+--   of adjacent characters as one change instead of
+--   two.
+--
+--   The significant difference is an extra case to
+--   doDiag, which checks if it's actually a
+--   transposition.
+--
+--   As there are a few ugly partial function calls
+--   there's property tests to ensure it doesn't
+--   crash :/ and obeys the laws.
+--
+editDistance :: Eq a => [a] -> [a] -> Int
+editDistance a b
+    = last (if lab == 0 then mainDiag
+            else if lab > 0 then lowers !! (lab - 1)
+                 else {- < 0 -}  uppers !! (-1 - lab))
+    where mainDiag = oneDiag a b (head uppers) (-1 : head lowers)
+          uppers = eachDiag a b (mainDiag : uppers) -- upper diagonals
+          lowers = eachDiag b a (mainDiag : lowers) -- lower diagonals
+          eachDiag _ [] _ = []
+          eachDiag _ _ [] = []
+          eachDiag a' (_:bs) (lastDiag:diags) = oneDiag a' bs nextDiag lastDiag : eachDiag a' bs diags
+              where nextDiag = head (tail diags)
+          oneDiag a' b' diagAbove diagBelow = thisdiag
+              where doDiag [] _ _ _ _ = []
+                    doDiag _ [] _ _ _ = []
+                    -- Check for a transposition
+                    doDiag (ach:ach':as) (bch:bch':bs) nw n w
+                      | ach' == bch && ach == bch'
+                      = nw : (doDiag (ach':as) (bch':bs) nw (tail n) (tail w))
+                    -- Usual case
+                    doDiag (ach:as) (bch:bs) nw n w = me : (doDiag as bs me (tail n) (tail w))
+                        where me = if ach == bch then nw else 1 + min3 (head w) nw (head n)
+                    firstelt = 1 + head diagBelow
+                    thisdiag = firstelt : doDiag a' b' firstelt diagAbove (tail diagBelow)
+          lab = length a - length b
+          min3 x y z = if x < y then x else min y z

--- a/Options/Applicative/Help/Types.hs
+++ b/Options/Applicative/Help/Types.hs
@@ -1,6 +1,6 @@
 module Options.Applicative.Help.Types (
-  ParserHelp(..),
-  renderHelp
+    ParserHelp (..)
+  , renderHelp
   ) where
 
 import Data.Semigroup
@@ -11,6 +11,7 @@ import Options.Applicative.Help.Pretty
 
 data ParserHelp = ParserHelp
   { helpError :: Chunk Doc
+  , helpSuggestions :: Chunk Doc
   , helpHeader :: Chunk Doc
   , helpUsage :: Chunk Doc
   , helpBody :: Chunk Doc
@@ -20,17 +21,17 @@ instance Show ParserHelp where
   showsPrec _ h = showString (renderHelp 80 h)
 
 instance Monoid ParserHelp where
-  mempty = ParserHelp mempty mempty mempty mempty mempty
+  mempty = ParserHelp mempty mempty mempty mempty mempty mempty
   mappend = (<>)
 
 instance Semigroup ParserHelp where
-  (ParserHelp e1 h1 u1 b1 f1) <> (ParserHelp e2 h2 u2 b2 f2)
-    = ParserHelp (mappend e1 e2) (mappend h1 h2)
-                 (mappend u1 u2) (mappend b1 b2)
-                 (mappend f1 f2)
+  (ParserHelp e1 s1 h1 u1 b1 f1) <> (ParserHelp e2 s2 h2 u2 b2 f2)
+    = ParserHelp (mappend e1 e2) (mappend s1 s2)
+                 (mappend h1 h2) (mappend u1 u2)
+                 (mappend b1 b2) (mappend f1 f2)
 
 helpText :: ParserHelp -> Doc
-helpText (ParserHelp e h u b f) = extractChunk . vsepChunks $ [e, h, u, b, f]
+helpText (ParserHelp e s h u b f) = extractChunk . vsepChunks $ [e, s, h, u, b, f]
 
 -- | Convert a help text to 'String'.
 renderHelp :: Int -> ParserHelp -> String

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -63,6 +63,7 @@ data ParseError
   | ShowHelpText
   | UnknownError
   | MissingError IsCmdStart SomeParser
+  | UnexpectedError String SomeParser
 
 data IsCmdStart = CmdStart | CmdCont
   deriving Show
@@ -343,8 +344,10 @@ data ArgPolicy
   deriving (Eq, Ord, Show)
 
 data OptHelpInfo = OptHelpInfo
-  { hinfoMulti :: Bool
-  , hinfoDefault :: Bool
+  { hinfoMulti :: Bool    -- ^ Whether this is part of a many or some (approximately)
+  , hinfoDefault :: Bool  -- ^ Whether this option has a default value
+  , hinfoUnreachableArgs :: Bool -- ^ If the result is a positional, if it can't be
+                                 --   accessed in the current parser position ( first arg )
   } deriving (Eq, Show)
 
 data OptTree a

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -112,9 +112,10 @@ library
                        Options.Applicative.Common,
                        Options.Applicative.Extra,
                        Options.Applicative.Help,
-                       Options.Applicative.Help.Pretty,
                        Options.Applicative.Help.Chunk,
                        Options.Applicative.Help.Core,
+                       Options.Applicative.Help.Levenshtein,
+                       Options.Applicative.Help.Pretty,
                        Options.Applicative.Help.Types,
                        Options.Applicative.Types,
                        Options.Applicative.Internal

--- a/tests/commands_header.err.txt
+++ b/tests/commands_header.err.txt
@@ -1,3 +1,6 @@
-Invalid option `-zzz'
+Invalid option `-zello'
+
+Did you mean this?
+    hello
 
 Usage: commands_header COMMAND

--- a/tests/commands_header_full.err.txt
+++ b/tests/commands_header_full.err.txt
@@ -1,4 +1,7 @@
-Invalid option `-zzz'
+Invalid option `-zello'
+
+Did you mean this?
+    hello
 
 foo
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -539,6 +539,19 @@ prop_many_pairs_lazy_progress = once $
       result = run i ["foo", "-abar", "baz"]
   in assertResult result $ \xs -> [(Just "bar", "foo"), (Nothing, "baz")] === xs
 
+prop_suggest :: Property
+prop_suggest = once $
+  let p2 = subparser (command "reachable"   (info (pure ()) idm))
+      p1 = subparser (command "unreachable" (info (pure ()) idm))
+      p  = (,) <$> p2 <*> p1
+      i  = info p idm
+      result = run i ["ureachable"]
+  in assertError result $ \failure ->
+    let (msg, _)  = renderFailure failure "prog"
+    in  counterexample msg
+       $  isInfixOf "Did you mean this?\n    reachable\n" msg
+      .&. not (isInfixOf "unreachable" msg)
+
 ---
 
 deriving instance Arbitrary a => Arbitrary (Chunk a)

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -74,9 +74,9 @@ prop_cmd_header :: Property
 prop_cmd_header = once $
   let i  = info (helper <*> Commands.sample) (header "foo")
       r1 = checkHelpTextWith (ExitFailure 1) defaultPrefs
-                    "commands_header" i ["-zzz"]
+                    "commands_header" i ["-zello"]
       r2 = checkHelpTextWith (ExitFailure 1) (prefs showHelpOnError)
-                    "commands_header_full" i ["-zzz"]
+                    "commands_header_full" i ["-zello"]
   in  (r1 .&&. r2)
 
 prop_cabal_conf :: Property
@@ -549,7 +549,7 @@ prop_suggest = once $
   in assertError result $ \failure ->
     let (msg, _)  = renderFailure failure "prog"
     in  counterexample msg
-       $  isInfixOf "Did you mean this?\n    reachable\n" msg
+       $  isInfixOf "Did you mean this?\n    reachable" msg
       .&. not (isInfixOf "unreachable" msg)
 
 ---

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -240,6 +240,22 @@ prop_completion_only_reachable = once . ioProperty $
     Failure _   -> return $ counterexample "unexpected failure" failed
     Success val -> return $ counterexample ("unexpected result " ++ show val) failed
 
+prop_completion_only_reachable_deep :: Property
+prop_completion_only_reachable_deep = once . ioProperty $
+  let p = (,)
+        <$> strArgument (completeWith ["seen"])
+        <*> strArgument (completeWith ["now-reachable"])
+      i = info p idm
+      result = run i [ "--bash-completion-index", "2"
+                     , "--bash-completion-word", "test-prog"
+                     , "--bash-completion-word", "seen" ]
+  in case result of
+    CompletionInvoked (CompletionResult err) -> do
+      completions <- lines <$> err "test"
+      return $ ["now-reachable"] === completions
+    Failure _   -> return $ counterexample "unexpected failure" failed
+    Success val -> return $ counterexample ("unexpected result " ++ show val) failed
+
 prop_bind_usage :: Property
 prop_bind_usage = once $
   let p = many (argument str (metavar "ARGS..."))


### PR DESCRIPTION
Uses a Levenshtein distance to see if there's a suitable
candidate for suggestions.

Also fixes a subtle bug in bash completions, where argument
completers from deeper into the parser would have their
possibilities added to the completion.

Fixes #222 