### PR TITLE
Allow overriding the help info of a Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Adds `overrideHelp` and `overrideHelpDoc`, to allow custom help documentation.
+
 ## Version 0.13.2.0 (9 Mar 2017)
 
 - Updated dependency bounds.

--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -5,6 +5,8 @@ module Options.Applicative.Extra (
   -- | This module contains high-level functions to run parsers.
   helper,
   hsubparser,
+  overrideHelp,
+  overrideHelpDoc,
   execParser,
   execParserMaybe,
   customExecParser,
@@ -56,6 +58,21 @@ hsubparser m = mkParser d g rdr
     rdr = CmdReader groupName cmds (fmap add_helper . subs)
     add_helper pinfo = pinfo
       { infoParser = infoParser pinfo <**> helper }
+
+-- | Overrides the help info of a 'Parser' - instead of using the help
+-- info from the 'Parser', it will use the provided list. The @Maybe
+-- String@ is used for the brief help text - use 'Nothing' to omit it
+-- from the brief help. The other two 'String's are used to specify the
+-- left hand and right hand side of the full help table.
+overrideHelp :: [(Maybe String, String, String)] -> Parser a -> Parser a
+overrideHelp hs = overrideHelpDoc (map stringsToDoc hs)
+  where
+    stringsToDoc (b, fl, fr) = (string <$> b, string fl, extractChunk (paragraph fr))
+
+-- | Like 'overrideHelp', but specified with
+-- 'Text.PrettyPrint.ANSI.Leijen.Doc' values.
+overrideHelpDoc :: [(Maybe Doc, Doc, Doc)] -> Parser a -> Parser a
+overrideHelpDoc = HelpP
 
 -- | Run a program description.
 --

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -208,6 +208,7 @@ data Parser a
   | forall x . MultP (Parser (x -> a)) (Parser x)
   | AltP (Parser a) (Parser a)
   | forall x . BindP (Parser x) (x -> Parser a)
+  | HelpP [(Maybe Doc, Doc, Doc)] (Parser a)
 
 instance Functor Parser where
   fmap f (NilP x) = NilP (fmap f x)
@@ -215,6 +216,7 @@ instance Functor Parser where
   fmap f (MultP p1 p2) = MultP (fmap (f.) p1) p2
   fmap f (AltP p1 p2) = AltP (fmap f p1) (fmap f p2)
   fmap f (BindP p k) = BindP p (fmap f . k)
+  fmap f (HelpP hs p) = HelpP hs (fmap f p)
 
 instance Applicative Parser where
   pure = NilP . Just
@@ -354,6 +356,7 @@ data OptTree a
   = Leaf a
   | MultNode [OptTree a]
   | AltNode [OptTree a]
+  | HelpOverrideNode [(Maybe Doc, Doc, Doc)] (OptTree a)
   deriving Show
 
 optVisibility :: Option a -> OptVisibility


### PR DESCRIPTION
This commit allows for specifying custom help info for a Parser.

The specific motivation for it is that it allows us to remove an ugly hack in stack and fix its bash completion.  In particular, we have a bunch of options that are enableable or disableable, like `--no-system-ghc` and `--system-ghc`.  Rather than list both, we have `--[no-]system-ghc` in the help list.  The current hack for this means that `--[no-]system-ghc` is an actual flag accepted by stack, and also breaks autocompletion! Argh!

Here's the stack PR that depends on this PR: https://github.com/commercialhaskell/stack/pull/3080

This will also be useful for things like `--PROG-options` and `--with-PROG`.  See, for example, this portion of the output of `cabal build --help`:

```
    --with-PROG=PATH    give the path to PROG
    --PROG-option=OPT   give an extra option to PROG (no need to quote options
                        containing spaces)
    --PROG-options=OPTS give extra options to PROG
```