### PR TITLE
Add a new modifier for editing an option description

### DIFF
--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -41,6 +41,7 @@ module Options.Applicative.Builder (
   ParseError(..),
   hidden,
   internal,
+  style,
   command,
   commandGroup,
   completeWith,
@@ -184,6 +185,18 @@ metavar var = optionMod $ \p -> p { propMetaVar = var }
 hidden :: Mod f a
 hidden = optionMod $ \p ->
   p { propVisibility = min Hidden (propVisibility p) }
+
+-- | Apply a function to the option description in the usage text.
+--
+-- > import Options.Applicative.Help
+-- > flag' () (short 't' <> style bold)
+--
+-- /NOTE/: This builder is more flexible than its name and example
+-- allude. One of the motivating examples for its addition was to
+-- used `const` to completely replace the usage text of an option.
+style :: ( Doc -> Doc ) -> Mod f a
+style x = optionMod $ \p ->
+  p { propDescMod = Just x }
 
 -- | Add a command to a subparser option.
 command :: String -> ParserInfo a -> Mod CommandFields a

--- a/Options/Applicative/Builder/Internal.hs
+++ b/Options/Applicative/Builder/Internal.hs
@@ -145,7 +145,9 @@ baseProps = OptProperties
   { propMetaVar = ""
   , propVisibility = Visible
   , propHelp = mempty
-  , propShowDefault = Nothing }
+  , propShowDefault = Nothing
+  , propDescMod = Nothing
+  }
 
 mkCommand :: Mod CommandFields a -> (Maybe String, [String], String -> Maybe (ParserInfo a))
 mkCommand m = (group, map fst cmds, (`lookup` cmds))

--- a/Options/Applicative/Help/Core.hs
+++ b/Options/Applicative/Help/Core.hs
@@ -65,7 +65,7 @@ optDesc pprefs style info opt =
         = mappend chunk suffix
         | otherwise
         = mappend (fmap parens chunk) suffix
-  in render desc'
+  in maybe id fmap (optDescMod opt) (render desc')
 
 -- | Generate descriptions for commands.
 cmdDesc :: Parser a -> [(Maybe String, Chunk Doc)]

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -39,7 +39,8 @@ module Options.Applicative.Types (
   optVisibility,
   optMetaVar,
   optHelp,
-  optShowDefault
+  optShowDefault,
+  optDescMod
   ) where
 
 import Control.Applicative
@@ -125,7 +126,17 @@ data OptProperties = OptProperties
   , propHelp :: Chunk Doc                 -- ^ help text for this option
   , propMetaVar :: String                 -- ^ metavariable for this option
   , propShowDefault :: Maybe String       -- ^ what to show in the help text as the default
-  } deriving Show
+  , propDescMod :: Maybe ( Doc -> Doc )   -- ^ a function to run over the brief description
+  }
+
+instance Show OptProperties where
+  showsPrec p (OptProperties pV pH pMV pSD _)
+    = showParen (p >= 11)
+    $ showString "OptProperties { propVisibility = " . showsPrec 0 pV
+    . showString ", propHelp = " . showsPrec 0 pH
+    . showString ", propMetaVar = " . showsPrec 0 pMV
+    . showString ", propShowDefault = " . showsPrec 0 pSD
+    . showString ", propDescMod = _ }"
 
 -- | A single option of a parser.
 data Option a = Option
@@ -371,3 +382,6 @@ optMetaVar = propMetaVar . optProps
 
 optShowDefault :: Option a -> Maybe String
 optShowDefault = propShowDefault . optProps
+
+optDescMod :: Option a -> Maybe ( Doc -> Doc )
+optDescMod = propDescMod . optProps


### PR DESCRIPTION
@mgsloan

Here's the general idea I mentioned in #251 

It touches less and I think gives a nicer level of expressiveness. I tried
`style (bold . underline)`
and it looked pretty good.

Your problem would be solved by adding to one of the flags
`style (const $ text "--[no]-whatever")` and hiding the other.

I'm not sure about the exact type or name of the builder yet, `Doc -> Doc` might actually do, as I don't think deleting or adding after it's been removed for other reasons is a good idea.