### PR TITLE
Add an error message for options which require arguments

### DIFF
--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -171,7 +171,7 @@ helpDoc doc = optionMod $ \p -> p { propHelp = Chunk doc }
 
 -- | Specify the error to display when no argument is provided to this option.
 noArgError :: ParseError -> Mod OptionFields a
-noArgError e = fieldMod $ \p -> p { optNoArgError = e }
+noArgError e = fieldMod $ \p -> p { optNoArgError = const e }
 
 -- | Specify a metavariable for the argument.
 --
@@ -318,7 +318,7 @@ option :: ReadM a -> Mod OptionFields a -> Parser a
 option r m = mkParser d g rdr
   where
     Mod f d g = metavar "ARG" `mappend` m
-    fields = f (OptionFields [] mempty (ErrorMsg ""))
+    fields = f (OptionFields [] mempty ExpectsArgError)
     crdr = CReader (optCompleter fields) r
     rdr = OptReader (optNames fields) crdr (optNoArgError fields)
 

--- a/Options/Applicative/Builder/Internal.hs
+++ b/Options/Applicative/Builder/Internal.hs
@@ -34,7 +34,7 @@ import Options.Applicative.Types
 data OptionFields a = OptionFields
   { optNames :: [OptName]
   , optCompleter :: Completer
-  , optNoArgError :: ParseError }
+  , optNoArgError :: String -> ParseError }
 
 data FlagFields a = FlagFields
   { flagNames :: [OptName]

--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -102,8 +102,8 @@ optMatches disambiguate opt (OptWord arg1 val) = case opt of
     Just $ do
       args <- get
       let mb_args = uncons $ maybeToList val ++ args
-      let missing_arg = lift $ missingArgP no_arg_err (crCompleter rdr)
-      (arg', args') <- maybe missing_arg return mb_args
+      let missing_arg = missingArgP (no_arg_err $ showOption arg1) (crCompleter rdr)
+      (arg', args') <- maybe (lift missing_arg) return mb_args
       put args'
       lift $ runReadM (withReadM (errorFor arg1) (crReader rdr)) arg'
 

--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -151,6 +151,7 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
       ErrorMsg {}        -> ExitFailure (infoFailureCode pinfo)
       UnknownError       -> ExitFailure (infoFailureCode pinfo)
       MissingError {}    -> ExitFailure (infoFailureCode pinfo)
+      ExpectsArgError {} -> ExitFailure (infoFailureCode pinfo)
       UnexpectedError {} -> ExitFailure (infoFailureCode pinfo)
       ShowHelpText       -> ExitSuccess
       InfoMsg {}         -> ExitSuccess
@@ -186,6 +187,9 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
 
       MissingError _ (SomeParser x)
         -> stringChunk "Missing:" <<+>> missingDesc pprefs x
+
+      ExpectsArgError x
+        -> stringChunk $ "The option `" ++ x ++ "` expects an argument."
 
       UnexpectedError arg _
         -> stringChunk msg'

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -63,6 +63,7 @@ data ParseError
   | ShowHelpText
   | UnknownError
   | MissingError IsCmdStart SomeParser
+  | ExpectsArgError String
   | UnexpectedError String SomeParser
 
 data IsCmdStart = CmdStart | CmdCont
@@ -189,11 +190,14 @@ instance Functor CReader where
 
 -- | An 'OptReader' defines whether an option matches an command line argument.
 data OptReader a
-  = OptReader [OptName] (CReader a) ParseError          -- ^ option reader
-  | FlagReader [OptName] !a                             -- ^ flag reader
-  | ArgReader (CReader a)                               -- ^ argument reader
-  | CmdReader (Maybe String)
-              [String] (String -> Maybe (ParserInfo a)) -- ^ command reader
+  = OptReader [OptName] (CReader a) (String -> ParseError)
+  -- ^ option reader
+  | FlagReader [OptName] !a
+  -- ^ flag reader
+  | ArgReader (CReader a)
+  -- ^ argument reader
+  | CmdReader (Maybe String) [String] (String -> Maybe (ParserInfo a))
+  -- ^ command reader
 
 instance Functor OptReader where
   fmap f (OptReader ns cr e) = OptReader ns (fmap f cr) e

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -532,6 +532,14 @@ prop_alt_missing_flags_described = once $
     let text = head . lines . fst $ renderFailure failure "test"
     in  "Missing: (-a ARG | -b ARG)" === text
 
+prop_missing_option_parameter_err :: Property
+prop_missing_option_parameter_err = once $
+  let p = option str (short 'a')
+      i = info p idm
+  in assertError (run i ["-a"]) $ \failure ->
+    let text = head . lines . fst $ renderFailure failure "test"
+    in  "The option `-a` expects an argument." === text
+
 prop_many_pairs_success :: Property
 prop_many_pairs_success = once $
   let p = many $ (,) <$> argument str idm <*> argument str idm


### PR DESCRIPTION
I believe this is the last situation in optparse-applicative where we don't emit an informative error message (by default).

Closes #249 