### PR TITLE
Fixup escaping when running compgen.

### DIFF
--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -241,14 +241,14 @@ commandGroup g = fieldMod $ \p ->
 
 -- | Add a list of possible completion values.
 completeWith :: HasCompleter f => [String] -> Mod f a
-completeWith xs = completer (listCompleter xs)
+completeWith = completer . listCompleter
 
 -- | Add a bash completion action. Common actions include @file@ and
 -- @directory@. See
 -- <http://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html#Programmable-Completion-Builtins>
 -- for a complete list.
 action :: HasCompleter f => String -> Mod f a
-action act = completer (bashCompleter act)
+action = completer . bashCompleter
 
 -- | Add a completer to an argument.
 --

--- a/Options/Applicative/Builder/Completer.hs
+++ b/Options/Applicative/Builder/Completer.hs
@@ -9,7 +9,7 @@ module Options.Applicative.Builder.Completer
 import Control.Applicative
 import Prelude
 import Control.Exception (IOException, try)
-import Data.List (isPrefixOf)
+import Data.List (isPrefixOf, isSuffixOf)
 import System.Process (readProcess)
 
 import Options.Applicative.Types
@@ -23,9 +23,40 @@ listCompleter = listIOCompleter . pure
 
 bashCompleter :: String -> Completer
 bashCompleter action = Completer $ \word -> do
-  let cmd = unwords ["compgen", "-A", action, "--", word]
+  let cmd = unwords ["compgen", "-A", action, "--", quote word]
   result <- tryIO $ readProcess "bash" ["-c", cmd] ""
   return . lines . either (const []) id $ result
 
 tryIO :: IO a -> IO (Either IOException a)
 tryIO = try
+
+-- | Strongly quote the string we pass to compgen.
+--
+-- We need to do this so bash doesn't expand out any ~ or other
+-- chars we want to complete on, or emit an end of line error
+-- when seeking the close to the quote.
+quote :: String -> String
+quote s =
+  case s of
+    -- It's already strongly quoted, so we
+    -- can use it mostly as is, but we must
+    -- ensure it's closed off at the end and
+    -- there's no single quotes in the
+    -- middle which might confuse bash.
+    ('\'' : rs) | isSuffixOf "'" rs
+               -> '\'' : foldr go [] rs
+                | otherwise
+               -> '\'' : foldr go "'" rs
+
+    -- We're not strongly quoted. Make it so.
+    -- We could be either weakly quoted or not
+    -- quoted at all, but it looks like this
+    -- actually works well for us either way.
+    elsewise   -> '\'' : foldr go "'" elsewise
+
+  where
+    -- If there's a single quote inside the
+    -- command: exit from the strong quote and
+    -- emit it the quote escaped, then resume.
+    go '\'' t = "'\\''" ++ t
+    go h t    = h : t

--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -277,7 +277,11 @@ treeMapParser g = simplify . go False False False g
       where r' = r || has_positional p1
     go m d r f (AltP p1 p2) = AltNode [go m d' r f p1, go m d' r f p2]
       where d' = d || has_default p1 || has_default p2
-    go _ d r f (BindP p _) = go True d r f p
+    go _ d r f (BindP p k) =
+      let go' = go True d r f p
+      in case evalParser p of
+        Nothing -> go'
+        Just aa -> MultNode [ go', go True d r f (k aa) ]
 
     has_positional :: Parser a -> Bool
     has_positional (NilP _) = False

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -267,6 +267,21 @@ prop_completion_only_reachable_deep = once . ioProperty $
     Failure _   -> return $ counterexample "unexpected failure" failed
     Success val -> return $ counterexample ("unexpected result " ++ show val) failed
 
+prop_completion_multi :: Property
+prop_completion_multi = once . ioProperty $
+  let p :: Parser [String]
+      p = many (strArgument (completeWith ["reachable"]))
+      i = info p idm
+      result = run i [ "--bash-completion-index", "3"
+                     , "--bash-completion-word", "test-prog"
+                     , "--bash-completion-word", "nope" ]
+  in case result of
+    CompletionInvoked (CompletionResult err) -> do
+      completions <- lines <$> err "test"
+      return $ ["reachable"] === completions
+    Failure _   -> return $ counterexample "unexpected failure" failed
+    Success val -> return $ counterexample ("unexpected result " ++ show val) failed
+
 prop_bind_usage :: Property
 prop_bind_usage = once $
   let p :: Parser [String]


### PR DESCRIPTION
Fixes a few bugs related to bash completion.

1) The quote bug mentioned in #252 
2) Premature `~` expansion.
3) Completions through binds (regression)
4) Support for Fish

Essentially we have to requote the string we pass into the
compgen, as we're not passing atoms to a command, but
instead a big string to a builtin. It's pretty rough, especially
as we need to take into account that we can complete on a
partially completed quoted block.

Seems to behave much like (exactly like?) the builtin default
when running with "file". I should figure out how to write a
test for this.