### PR TITLE
Update Common.hs to expose stepParser

### DIFF
--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -47,7 +47,8 @@ module Options.Applicative.Common (
   -- * Low-level utilities
   mapParser,
   treeMapParser,
-  optionNames
+  optionNames,
+  stepParser
   ) where
 
 import Control.Applicative


### PR DESCRIPTION
stepParser is useful in building an incremental parser. Without exposing this, one needs to copy nearly all the contents of Options.Applicative.Internal. This change would save me from copying hundreds of LoC and save me from depending on internals that are likely to change.