### PR TITLE
Topic/completion after double dash

### DIFF
--- a/Options/Applicative/BashCompletion.hs
+++ b/Options/Applicative/BashCompletion.hs
@@ -88,14 +88,17 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
     -- We therefore now check to see that
     -- hinfoUnreachableArgs is off before running the
     -- completion for position arguments.
+    --
+    -- For options and flags, ensure that the user
+    -- hasn't disabled them with `--`.
     opt_completions argPolicy hinfo opt = case optMain opt of
       OptReader ns _ _
-         | argPolicy /=  AllPositionals
+         | argPolicy /= AllPositionals
         -> return . add_opt_help opt $ show_names ns
          | otherwise
         -> return []
       FlagReader ns _
-         | argPolicy /=  AllPositionals
+         | argPolicy /= AllPositionals
         -> return . add_opt_help opt $ show_names ns
          | otherwise
         -> return []

--- a/Options/Applicative/BashCompletion.hs
+++ b/Options/Applicative/BashCompletion.hs
@@ -9,9 +9,9 @@ module Options.Applicative.BashCompletion
 
 import Control.Applicative
 import Prelude
-import Data.Foldable (asum)
-import Data.List (isPrefixOf)
-import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Foldable ( asum )
+import Data.List ( isPrefixOf )
+import Data.Maybe ( fromMaybe, listToMaybe )
 
 import Options.Applicative.Builder
 import Options.Applicative.Common
@@ -66,16 +66,19 @@ bashCompletionParser pinfo pprefs = complParser
 
 bashCompletionQuery :: ParserInfo a -> ParserPrefs -> Richness -> [String] -> Int -> String -> IO [String]
 bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl pprefs of
-  Just (Left (SomeParser p)) -> list_options p
-  Just (Right c)             -> run_completer c
-  _                          -> return []
+  Just (Left (SomeParser p, a))
+    -> list_options a p
+  Just (Right c)
+    -> run_completer c
+  Nothing
+    -> return []
   where
     compl = runParserInfo pinfo (drop 1 ws')
 
-    list_options
+    list_options a
       = fmap concat
       . sequence
-      . mapParser opt_completions
+      . mapParser (opt_completions a)
 
     --
     -- Prior to 0.14 there was a subtle bug which would
@@ -85,17 +88,27 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
     -- We therefore now check to see that
     -- hinfoUnreachableArgs is off before running the
     -- completion for position arguments.
-    opt_completions hinfo opt = case optMain opt of
-      OptReader ns _ _ -> return . add_opt_help opt $ show_names ns
-      FlagReader ns _  -> return . add_opt_help opt $ show_names ns
-      ArgReader rdr     | hinfoUnreachableArgs hinfo
-                       -> return []
-                        | otherwise
-                       -> run_completer (crCompleter rdr)
-      CmdReader _ ns p  | hinfoUnreachableArgs hinfo
-                       -> return []
-                        | otherwise
-                       -> return . add_cmd_help p $ filter_names ns
+    opt_completions argPolicy hinfo opt = case optMain opt of
+      OptReader ns _ _
+         | argPolicy /=  AllPositionals
+        -> return . add_opt_help opt $ show_names ns
+         | otherwise
+        -> return []
+      FlagReader ns _
+         | argPolicy /=  AllPositionals
+        -> return . add_opt_help opt $ show_names ns
+         | otherwise
+        -> return []
+      ArgReader rdr
+         | hinfoUnreachableArgs hinfo
+        -> return []
+         | otherwise
+        -> run_completer (crCompleter rdr)
+      CmdReader _ ns p
+         | hinfoUnreachableArgs hinfo
+        -> return []
+         | otherwise
+        -> return . add_cmd_help p $ filter_names ns
 
     -- When doing enriched completions, add any help specified
     -- to the completion variables (tab separated).

--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -205,7 +205,7 @@ runParser :: MonadP m => ArgPolicy -> IsCmdStart -> Parser a -> Args -> m (a, Ar
 runParser policy _ p ("--" : argt) | policy /= AllPositionals
                                    = runParser AllPositionals CmdCont p argt
 runParser policy isCmdStart p args = case args of
-  [] -> exitP isCmdStart p result
+  [] -> exitP isCmdStart policy p result
   (arg : argt) -> do
     prefs <- getPrefs
     (mp', args') <- do_step prefs arg argt

--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -210,7 +210,7 @@ runParser policy isCmdStart p args = case args of
     prefs <- getPrefs
     (mp', args') <- do_step prefs arg argt
     case mp' of
-      Nothing -> hoistMaybe result <|> parseError arg p
+      Nothing -> hoistMaybe result <|> parseError arg policy p
       Just p' -> runParser (newPolicy arg) CmdCont p' args'
   where
     result = (,) <$> evalParser p <*> pure args
@@ -222,8 +222,8 @@ runParser policy isCmdStart p args = case args of
       NoIntersperse -> if isJust (parseWord a) then NoIntersperse else AllPositionals
       x             -> x
 
-parseError :: MonadP m => String -> Parser x -> m a
-parseError arg = errorP . UnexpectedError arg . SomeParser
+parseError :: MonadP m => String -> ArgPolicy -> Parser x -> m a
+parseError arg policy = errorP . UnexpectedError arg policy . SomeParser
 
 runParserInfo :: MonadP m => ParserInfo a -> Args -> m a
 runParserInfo i = runParserFully (infoPolicy i) (infoParser i)
@@ -233,7 +233,7 @@ runParserFully policy p args = do
   (r, args') <- runParser policy CmdStart p args
   case args' of
     []  -> return r
-    a:_ -> parseError a (pure ())
+    a:_ -> parseError a policy (pure ())
 
 -- | The default value of a 'Parser'.  This function returns an error if any of
 -- the options don't have a default value.

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -65,7 +65,7 @@ data ParseError
   | UnknownError
   | MissingError IsCmdStart SomeParser
   | ExpectsArgError String
-  | UnexpectedError String SomeParser
+  | UnexpectedError String ArgPolicy SomeParser
 
 data IsCmdStart = CmdStart | CmdCont
   deriving Show

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -235,6 +235,22 @@ prop_completion = once . ioProperty $
     Failure _   -> return $ counterexample "unexpected failure" failed
     Success val -> return $ counterexample ("unexpected result " ++ show val) failed
 
+prop_completion_opt_after_double_dash :: Property
+prop_completion_opt_after_double_dash = once . ioProperty $
+  let p = (,)
+        <$> strOption (long "foo" <> value "")
+        <*> argument readerAsk (completeWith ["bar"])
+      i = info p idm
+      result = run i ["--bash-completion-index", "2"
+                    , "--bash-completion-word", "test"
+                    , "--bash-completion-word", "--"]
+  in case result of
+    CompletionInvoked (CompletionResult err) -> do
+      completions <- lines <$> err "test"
+      return $ ["bar"] === completions
+    Failure _   -> return $ counterexample "unexpected failure" failed
+    Success val -> return $ counterexample ("unexpected result " ++ show val) failed
+
 prop_completion_only_reachable :: Property
 prop_completion_only_reachable = once . ioProperty $
   let p :: Parser (String,String)


### PR DESCRIPTION
This actually fixes #172

Disabling them for the parse wasn't being pulled though to the completions and suggestions, as we weren't able to keep track of the policy being used at the time.

This adds this context to `exitP` for the completions, and `UnexpectedError` for the suggestions, then, if the policy is `AllPositionals`, omits flags and options.
