### PR TITLE
Explicitly export all functions and types, instead of the modules

### DIFF
--- a/Options/Applicative.hs
+++ b/Options/Applicative.hs
@@ -43,12 +43,12 @@ module Options.Applicative (
 
   -- ** Parser builders
   --
-  -- | This module contains utility functions and combinators to create parsers
+  -- | This section contains utility functions and combinators to create parsers
   -- for individual options.
   --
   -- Each parser builder takes an option modifier. A modifier can be created by
-  -- composing the basic modifiers provided by this module using the 'Monoid'
-  -- operations 'mempty' and 'mappend', or their aliases 'idm' and '<>'.
+  -- composing the basic modifiers provided by here using the 'Monoid' operations
+  -- 'mempty' and 'mappend', or their aliases 'idm' and '<>'.
   --
   -- For example:
   --
@@ -71,19 +71,18 @@ module Options.Applicative (
   subparser,
   hsubparser,
 
-  nullOption,
-
   abortOption,
   infoOption,
   helper,
 
   -- ** Modifiers
   --
-  -- | 'Parser' builders take a modifier, which can be composed as a monoid.
+  -- | 'Parser' builders take a modifier, which represents a modification of the
+  -- properties of an option, and can be composed as a monoid.
   --
   -- Contraints are often used to ensure that the modifiers can be sensibly applied.
   -- For example, positional arguments can't be specified by long or short names,
-  -- So the 'HasName' constraint ensures we have a flag or option.
+  -- so the 'HasName' constraint is used to ensure we have a flag or option.
   Mod,
 
   short,
@@ -113,7 +112,16 @@ module Options.Applicative (
 
   -- ** Readers
   --
-  -- | A collection of basic 'Option' readers.
+  -- | A reader is used by the 'option' and 'argument' builders to parse
+  -- the data passed by the user on the command line into a data type.
+  --
+  -- The most common are 'str' which is used for 'String' like types,
+  -- including 'ByteString' and 'Text'; and 'auto', which uses the 'Read'
+  -- typeclass, and is good for simple types like 'Int' or 'Double'.
+  --
+  -- More complex types can use the 'eitherReader' or 'maybeReader'
+  -- functions to pattern match or use a more expressive parser like a
+  -- member of the 'Parsec' family.
   ReadM,
 
   auto,
@@ -137,6 +145,7 @@ module Options.Applicative (
   -- 'InfoMod' modifiers.
   --
   info,
+
   ParserInfo(..),
 
   InfoMod,
@@ -154,13 +163,10 @@ module Options.Applicative (
 
   -- * Running parsers
   --
-  -- | The execParser family are used to run parsers
+  -- | The execParser family of functions are used to run parsers
   execParser,
   customExecParser,
   execParserPure,
-
-  execParserMaybe,
-  customExecParserMaybe,
 
   -- ** Handling parser results manually
   getParseResult,
@@ -186,33 +192,30 @@ module Options.Applicative (
   columns,
   defaultPrefs,
 
-  -- * Types
-  ParseError(..),
-  ParserFailure(..),
-  ParserResult(..),
-  CompletionResult(..),
-
-  -- * Internal
-
-  -- ** Completion Builders
+  -- * Completions
+  --
+  -- | optparse-applicative supplies a rich completion system for bash,
+  -- zsh, and fish shells.
+  --
+  -- 'Completer' functions are used for option and argument to complete
+  -- their values.
+  --
+  -- Use the 'completer' builder to use these.
+  -- The 'action' and 'completeWith' builders are also provided for
+  -- convenience, to use 'bashCompleter' and 'listCompleter' as a 'Mod'.
   Completer,
   mkCompleter,
   listIOCompleter,
+
   listCompleter,
   bashCompleter,
 
-  -- ** Parsers Runners
-  runParserInfo,
-  runParserFully,
-  runParser,
-  evalParser,
-
-  -- ** Low-level utilities
-  mapParser,
-  treeMapParser,
-  optionNames,
-  liftOpt,
-  showOption,
+  -- * Types
+  ParseError(..),
+  ParserHelp(..),
+  ParserFailure(..),
+  ParserResult(..),
+  CompletionResult(..)
 
   ) where
 
@@ -223,5 +226,6 @@ import Options.Applicative.Common
 import Options.Applicative.Builder
 import Options.Applicative.Builder.Completer
 import Options.Applicative.Extra
+import Options.Applicative.Types
 
 {-# ANN module "HLint: ignore Use import/export shortcut" #-}

--- a/Options/Applicative.hs
+++ b/Options/Applicative.hs
@@ -1,30 +1,219 @@
 module Options.Applicative (
   -- * Applicative option parsers
   --
-  -- | This is an empty module which simply re-exports all the public definitions
-  -- of this package.
+  -- | This module exports all one should need for defining and using
+  -- optparse-applicative command line option parsers.
   --
   -- See <https://github.com/pcapriotti/optparse-applicative> for a tutorial,
   -- and a general introduction to applicative option parsers.
   --
-  -- See the documentation of individual modules for more details.
+  -- See the sections below for more detail
 
   -- * Exported modules
   --
   -- | The standard @Applicative@ module is re-exported here for convenience.
   module Control.Applicative,
 
-  -- | Parser type and low-level parsing functionality.
-  module Options.Applicative.Common,
+  -- * Option Parsers
+  --
+  -- | A 'Parser' is the core type in optparse-applicative. A value of type
+  -- @Parser a@ represents a specification for a set of options, which will
+  -- yield a value of type a when the command line arguments are successfully
+  -- parsed.
+  --
+  -- There are several types of primitive 'Parser'.
+  --
+  -- * Flags: simple no-argument options. When a flag is encountered on the
+  -- command line, its value is returned.
+  --
+  -- * Options: options with an argument. An option can define a /reader/,
+  -- which converts its argument from String to the desired value, or throws a
+  -- parse error if the argument does not validate correctly.
+  --
+  -- * Arguments: positional arguments, validated in the same way as option
+  -- arguments.
+  --
+  -- * Commands. A command defines a completely independent sub-parser. When a
+  -- command is encountered, the whole command line is passed to the
+  -- corresponding parser.
+  --
+  -- See the "Parser Builders" section for how to construct and customise
+  -- these parsers.
+  Parser,
 
-  -- | Utilities to build parsers out of basic primitives.
-  module Options.Applicative.Builder,
+  -- ** Parser builders
+  --
+  -- | This module contains utility functions and combinators to create parsers
+  -- for individual options.
+  --
+  -- Each parser builder takes an option modifier. A modifier can be created by
+  -- composing the basic modifiers provided by this module using the 'Monoid'
+  -- operations 'mempty' and 'mappend', or their aliases 'idm' and '<>'.
+  --
+  -- For example:
+  --
+  -- > out = strOption
+  -- >     ( long "output"
+  -- >    <> short 'o'
+  -- >    <> metavar "FILENAME" )
+  --
+  -- creates a parser for an option called \"output\".
+  flag,
+  flag',
+  switch,
 
-  -- | Common completion functions.
-  module Options.Applicative.Builder.Completer,
+  strOption,
+  option,
 
-  -- | Utilities to run parsers and display a help text.
-  module Options.Applicative.Extra,
+  strArgument,
+  argument,
+
+  subparser,
+  hsubparser,
+
+  nullOption,
+
+  abortOption,
+  infoOption,
+  helper,
+
+  -- ** Modifiers
+  --
+  -- | 'Parser' builders take a modifier, which can be composed as a monoid.
+  --
+  -- Contraints are often used to ensure that the modifiers can be sensibly applied.
+  -- For example, positional arguments can't be specified by long or short names,
+  -- So the 'HasName' constraint ensures we have a flag or option.
+  Mod,
+
+  short,
+  long,
+  help,
+  helpDoc,
+  value,
+  showDefaultWith,
+  showDefault,
+  metavar,
+  noArgError,
+  hidden,
+  internal,
+  style,
+  command,
+  commandGroup,
+  completeWith,
+  action,
+  completer,
+  idm,
+  mappend,
+
+  OptionFields,
+  FlagFields,
+  ArgumentFields,
+  CommandFields,
+
+  -- ** Readers
+  --
+  -- | A collection of basic 'Option' readers.
+  ReadM,
+
+  auto,
+  str,
+  maybeReader,
+  eitherReader,
+  disabled,
+  readerAbort,
+  readerError,
+
+  -- * Program descriptions
+  --
+  -- ** 'ParserInfo'
+  --
+  -- | A 'ParserInfo' describes a command line program, used to generate a help
+  -- screen. Two help modes are supported: brief and full. In brief mode, only
+  -- an option and argument summary is displayed, while in full mode each
+  -- available option and command, including hidden ones, is described.
+  --
+  -- A 'ParserInfo' should be created with the 'info' function and a set of
+  -- 'InfoMod' modifiers.
+  --
+  info,
+  ParserInfo(..),
+
+  InfoMod,
+  fullDesc,
+  briefDesc,
+  header,
+  headerDoc,
+  footer,
+  footerDoc,
+  progDesc,
+  progDescDoc,
+  failureCode,
+  noIntersperse,
+  forwardOptions,
+
+  -- * Running parsers
+  --
+  -- | The execParser family are used to run parsers
+  execParser,
+  customExecParser,
+  execParserPure,
+
+  execParserMaybe,
+  customExecParserMaybe,
+
+  -- ** Handling parser results manually
+  getParseResult,
+  handleParseResult,
+  parserFailure,
+  renderFailure,
+  overFailure,
+
+  -- ** 'ParserPrefs'
+  --
+  -- | A 'ParserPrefs' contains general preferences for all command-line
+  -- options, and should be built with the 'prefs' function.
+  prefs,
+
+  ParserPrefs(..),
+
+  PrefsMod,
+  multiSuffix,
+  disambiguate,
+  showHelpOnError,
+  showHelpOnEmpty,
+  noBacktrack,
+  columns,
+  defaultPrefs,
+
+  -- * Types
+  ParseError(..),
+  ParserFailure(..),
+  ParserResult(..),
+  CompletionResult(..),
+
+  -- * Internal
+
+  -- ** Completion Builders
+  Completer,
+  mkCompleter,
+  listIOCompleter,
+  listCompleter,
+  bashCompleter,
+
+  -- ** Parsers Runners
+  runParserInfo,
+  runParserFully,
+  runParser,
+  evalParser,
+
+  -- ** Low-level utilities
+  mapParser,
+  treeMapParser,
+  optionNames,
+  liftOpt,
+  showOption,
+
   ) where
 
 -- reexport Applicative here for convenience

--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -128,12 +128,11 @@ str = fromString <$> readerAsk
 --
 -- As an example, one can create a ReadM from an attoparsec Parser
 -- easily with
--- @
--- import qualified Data.Attoparsec.Text as A
--- import qualified Data.Text as T
--- attoparsecReader :: A.Parser a => ReadM a
--- attoparsecReader p = eitherReader (A.parseOnly p . T.pack)
--- @
+--
+-- > import qualified Data.Attoparsec.Text as A
+-- > import qualified Data.Text as T
+-- > attoparsecReader :: A.Parser a => ReadM a
+-- > attoparsecReader p = eitherReader (A.parseOnly p . T.pack)
 eitherReader :: (String -> Either String a) -> ReadM a
 eitherReader f = readerAsk >>= either readerError return . f
 
@@ -217,6 +216,7 @@ style x = optionMod $ \p ->
 -- | Add a command to a subparser option.
 --
 -- Suggested usage for multiple commands is to add them to a single subparser. e.g.
+--
 -- @
 -- sample :: Parser Sample
 -- sample = subparser

--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -118,9 +118,6 @@ auto = eitherReader $ \arg -> case reads arg of
 -- | String 'Option' reader.
 --
 --   Polymorphic over the `IsString` type class since 0.14.
---
---   For a non-polymorphic version returning 'String', use
---   `readerAsk`.
 str :: IsString s => ReadM s
 str = fromString <$> readerAsk
 

--- a/Options/Applicative/Builder/Completer.hs
+++ b/Options/Applicative/Builder/Completer.hs
@@ -14,13 +14,22 @@ import System.Process (readProcess)
 
 import Options.Applicative.Types
 
+-- | Create a 'Completer' from an IO action
 listIOCompleter :: IO [String] -> Completer
 listIOCompleter ss = Completer $ \s ->
   filter (isPrefixOf s) <$> ss
 
+-- | Create a 'Completer' from a constant
+-- list of strings.
 listCompleter :: [String] -> Completer
 listCompleter = listIOCompleter . pure
 
+-- | Run a compgen completion action.
+--
+-- Common actions include @file@ and
+-- @directory@. See
+-- <http://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html#Programmable-Completion-Builtins>
+-- for a complete list.
 bashCompleter :: String -> Completer
 bashCompleter action = Completer $ \word -> do
   let cmd = unwords ["compgen", "-A", action, "--", requote word]

--- a/Options/Applicative/Builder/Internal.hs
+++ b/Options/Applicative/Builder/Internal.hs
@@ -118,7 +118,7 @@ instance Semigroup (DefaultProp a) where
 --
 -- Modifiers are instances of 'Monoid', and can be composed as such.
 --
--- You rarely need to deal with modifiers directly, as most of the times it is
+-- One rarely needs to deal with modifiers directly, as most of the times it is
 -- sufficient to pass them to builders (such as 'strOption' or 'flag') to
 -- create options (see 'Options.Applicative.Builder').
 data Mod f a = Mod (f a -> f a)

--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -38,6 +38,13 @@ import Options.Applicative.Internal
 import Options.Applicative.Types
 
 -- | A hidden \"helper\" option which always fails.
+--
+-- A common usage pattern is to apply this applicatively when
+-- creating a 'ParserInfo'
+--
+-- > opts :: ParserInfo Sample
+-- > opts = info (sample <**> helper) mempty
+
 helper :: Parser (a -> a)
 helper = abortOption ShowHelpText $ mconcat
   [ long "help"

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -275,9 +275,11 @@ instance Alternative Parser where
   many p = fromM $ manyM p
   some p = fromM $ (:) <$> oneM p <*> manyM p
 
+-- | A shell complete function.
 newtype Completer = Completer
   { runCompleter :: String -> IO [String] }
 
+-- | Smart constructor for a 'Completer'
 mkCompleter :: (String -> IO [String]) -> Completer
 mkCompleter = Completer
 


### PR DESCRIPTION
Although it's a bit more work, being explicit about exported functions makes the haddocks much nicer.