### PR TITLE
Fix type signature in eitherReader example

### DIFF
--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -128,7 +128,7 @@ str = fromString <$> readerAsk
 --
 -- > import qualified Data.Attoparsec.Text as A
 -- > import qualified Data.Text as T
--- > attoparsecReader :: A.Parser a => ReadM a
+-- > attoparsecReader :: A.Parser a -> ReadM a
 -- > attoparsecReader p = eitherReader (A.parseOnly p . T.pack)
 eitherReader :: (String -> Either String a) -> ReadM a
 eitherReader f = readerAsk >>= either readerError return . f


### PR DESCRIPTION
In the example for `eitherReader`, the type signature for `attoparsecReader` has `A.Parser a` as a type constraint where it should be a type.