### PR TITLE
tidy up dependencies

### DIFF
--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -75,9 +75,11 @@ library
                        Options.Applicative.Internal
 
 
+  if impl(ghc <7.10)
+    build-depends:     transformers-compat             >= 0.3 && < 0.7
+
   build-depends:       base                            == 4.*
                      , transformers                    >= 0.2 && < 0.6
-                     , transformers-compat             >= 0.3 && < 0.7
                      , process                         >= 1.0 && < 1.7
                      , ansi-wl-pprint                  >= 0.6.6 && < 0.7
 


### PR DESCRIPTION
This removes a dependency on `transformers-compat` where unnecessary.