### PR TITLE
relaxed Monoid constraint to Semigroup for the Monoid Chunk instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 env:
- - GHCVER=7.0.4
- - GHCVER=7.2.2
  - GHCVER=7.4.2
  - GHCVER=7.6.3
  - GHCVER=7.8.4

--- a/Options/Applicative/Help/Chunk.hs
+++ b/Options/Applicative/Help/Chunk.hs
@@ -45,10 +45,10 @@ instance Monad Chunk where
   return = pure
   m >>= f = Chunk $ unChunk m >>= unChunk . f
 
-instance Monoid a => Semigroup (Chunk a) where
-  (<>) = chunked mappend
+instance Semigroup a => Semigroup (Chunk a) where
+  (<>) = chunked (<>)
 
-instance Monoid a => Monoid (Chunk a) where
+instance Semigroup a => Monoid (Chunk a) where
   mempty = Chunk Nothing
   mappend = (<>)
 

--- a/Options/Applicative/Help/Chunk.hs
+++ b/Options/Applicative/Help/Chunk.hs
@@ -69,7 +69,7 @@ chunked f (Chunk (Just x)) (Chunk (Just y)) = Chunk (Just (f x y))
 --
 -- > isEmpty . listToChunk = null
 -- > listToChunk = mconcat . fmap pure
-listToChunk :: Monoid a => [a] -> Chunk a
+listToChunk :: (Semigroup a, Monoid a) => [a] -> Chunk a
 listToChunk [] = mempty
 listToChunk xs = pure (mconcat xs)
 

--- a/Options/Applicative/Help/Chunk.hs
+++ b/Options/Applicative/Help/Chunk.hs
@@ -16,6 +16,7 @@ module Options.Applicative.Help.Chunk
 
 import Control.Applicative
 import Control.Monad
+import Data.List.NonEmpty ( NonEmpty(..) )
 import Data.Maybe
 import Data.Semigroup
 import Prelude
@@ -69,9 +70,9 @@ chunked f (Chunk (Just x)) (Chunk (Just y)) = Chunk (Just (f x y))
 --
 -- > isEmpty . listToChunk = null
 -- > listToChunk = mconcat . fmap pure
-listToChunk :: (Semigroup a, Monoid a) => [a] -> Chunk a
+listToChunk :: Semigroup a => [a] -> Chunk a
 listToChunk [] = mempty
-listToChunk xs = pure (mconcat xs)
+listToChunk (x:xs) = pure (sconcat (x :| xs))
 
 -- | Part of a constrained comonad instance.
 --

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -73,7 +73,7 @@ library
                      , transformers                    >= 0.2 && < 0.6
                      , transformers-compat             >= 0.3 && < 0.7
                      , process                         >= 1.0 && < 1.7
-                     , ansi-wl-pprint                  >= 0.6.6 && < 0.7
+                     , ansi-wl-pprint                  >= 0.6.8 && < 0.7
 
   if !impl(ghc >= 8)
     build-depends:     semigroups                      >= 0.10 && < 0.19


### PR DESCRIPTION
Since `Chunk`s are supposed to lift a semigroup to a monoid by adding an identity, I thought it made sense to relax the `Monoid` constraint on the type parameter accordingly. 