### PR TITLE
potential feature addition #327 -- optional equality sign in help

### DIFF
--- a/Options/Applicative.hs
+++ b/Options/Applicative.hs
@@ -195,7 +195,7 @@ module Options.Applicative (
   noBacktrack,
   subparserInline,
   columns,
-  longEquals,
+  helpLongEquals,
   defaultPrefs,
 
   -- * Completions

--- a/Options/Applicative.hs
+++ b/Options/Applicative.hs
@@ -195,6 +195,7 @@ module Options.Applicative (
   noBacktrack,
   subparserInline,
   columns,
+  longEquals,
   defaultPrefs,
 
   -- * Completions

--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -85,6 +85,7 @@ module Options.Applicative.Builder (
   noBacktrack,
   subparserInline,
   columns,
+  longEquals,
   prefs,
   defaultPrefs,
 
@@ -500,6 +501,10 @@ subparserInline = PrefsMod $ \p -> p { prefBacktrack = SubparserInline }
 columns :: Int -> PrefsMod
 columns cols = PrefsMod $ \p -> p { prefColumns = cols }
 
+-- | Show equals signs in usage and help text for options with long names.
+longEquals :: PrefsMod
+longEquals = PrefsMod $ \p -> p { prefLongEquals = True }
+
 -- | Create a `ParserPrefs` given a modifier
 prefs :: PrefsMod -> ParserPrefs
 prefs m = applyPrefsMod m base
@@ -510,7 +515,8 @@ prefs m = applyPrefsMod m base
       , prefShowHelpOnError = False
       , prefShowHelpOnEmpty = False
       , prefBacktrack = Backtrack
-      , prefColumns = 80 }
+      , prefColumns = 80
+      , prefLongEquals = False }
 
 -- Convenience shortcuts
 

--- a/Options/Applicative/Builder.hs
+++ b/Options/Applicative/Builder.hs
@@ -85,7 +85,7 @@ module Options.Applicative.Builder (
   noBacktrack,
   subparserInline,
   columns,
-  longEquals,
+  helpLongEquals,
   prefs,
   defaultPrefs,
 
@@ -501,9 +501,10 @@ subparserInline = PrefsMod $ \p -> p { prefBacktrack = SubparserInline }
 columns :: Int -> PrefsMod
 columns cols = PrefsMod $ \p -> p { prefColumns = cols }
 
--- | Show equals signs in usage and help text for options with long names.
-longEquals :: PrefsMod
-longEquals = PrefsMod $ \p -> p { prefLongEquals = True }
+-- | Show equals sign, rather than space, in usage and help text for options with
+-- long names.
+helpLongEquals :: PrefsMod
+helpLongEquals = PrefsMod $ \p -> p { prefHelpLongEquals = True }
 
 -- | Create a `ParserPrefs` given a modifier
 prefs :: PrefsMod -> ParserPrefs
@@ -516,7 +517,7 @@ prefs m = applyPrefsMod m base
       , prefShowHelpOnEmpty = False
       , prefBacktrack = Backtrack
       , prefColumns = 80
-      , prefLongEquals = False }
+      , prefHelpLongEquals = False }
 
 -- Convenience shortcuts
 

--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -69,7 +69,7 @@ showOption (OptShort n) = '-' : [n]
 -- | Like 'showOption', but puts an equals sign or a space after long options if the
 -- 'ParserPrefs' indicate we should do so.
 showOptionEquals :: ParserPrefs -> OptName -> String
-showOptionEquals prefs (OptLong n) = "--" ++ n ++ (if prefLongEquals prefs then "=" else "")
+showOptionEquals prefs (OptLong n) = "--" ++ n ++ (if prefHelpLongEquals prefs then "=" else "")
 showOptionEquals _ (OptShort n) = '-' : [n]
 
 optionNames :: OptReader a -> [OptName]

--- a/Options/Applicative/Common.hs
+++ b/Options/Applicative/Common.hs
@@ -22,6 +22,7 @@ module Options.Applicative.Common (
   Parser,
   liftOpt,
   showOption,
+  showOptionEquals,
 
   -- * Program descriptions
   --
@@ -64,6 +65,12 @@ import Options.Applicative.Types
 showOption :: OptName -> String
 showOption (OptLong n) = "--" ++ n
 showOption (OptShort n) = '-' : [n]
+
+-- | Like 'showOption', but puts an equals sign or a space after long options if the
+-- 'ParserPrefs' indicate we should do so.
+showOptionEquals :: ParserPrefs -> OptName -> String
+showOptionEquals prefs (OptLong n) = "--" ++ n ++ (if prefLongEquals prefs then "=" else "")
+showOptionEquals _ (OptShort n) = '-' : [n]
 
 optionNames :: OptReader a -> [OptName]
 optionNames (OptReader names _ _) = names

--- a/Options/Applicative/Extra.hs
+++ b/Options/Applicative/Extra.hs
@@ -258,7 +258,7 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
             -- reader also ensure that it can be immediately
             -- reachable from where the error was given.
             opt_completions hinfo opt = case optMain opt of
-              OptReader ns _ _ -> fmap showOption ns
+              OptReader ns _ _ -> fmap (showOptionEquals pprefs) ns
               FlagReader ns _  -> fmap showOption ns
               ArgReader _      -> []
               CmdReader _ ns _  | hinfoUnreachableArgs hinfo

--- a/Options/Applicative/Help/Core.hs
+++ b/Options/Applicative/Help/Core.hs
@@ -44,7 +44,7 @@ optDesc pprefs style info opt =
             | otherwise = map (string . showOptionEquals pprefs) (sort ns)
       isLong (OptLong _) = True
       isLong _ = False
-      has_equals = any isLong ns && prefLongEquals pprefs
+      has_equals = any isLong ns && prefHelpLongEquals pprefs
       desc | has_equals = listToChunk (intersperse (descSep style) descs) <> mv
            | otherwise = listToChunk (intersperse (descSep style) descs) <<+>> mv
       show_opt

--- a/Options/Applicative/Help/Core.hs
+++ b/Options/Applicative/Help/Core.hs
@@ -37,8 +37,16 @@ optDesc :: ParserPrefs -> OptDescStyle -> OptHelpInfo -> Option a -> (Chunk Doc,
 optDesc pprefs style info opt =
   let ns = optionNames $ optMain opt
       mv = stringChunk $ optMetaVar opt
-      descs = map (string . showOption) (sort ns)
-      desc  = listToChunk (intersperse (descSep style) descs) <<+>> mv
+      has_arg = case mv of
+        Chunk Nothing -> True
+        _ -> False
+      descs | has_arg = map (string . showOption) (sort ns)
+            | otherwise = map (string . showOptionEquals pprefs) (sort ns)
+      isLong (OptLong _) = True
+      isLong _ = False
+      has_equals = any isLong ns && prefLongEquals pprefs
+      desc | has_equals = listToChunk (intersperse (descSep style) descs) <> mv
+           | otherwise = listToChunk (intersperse (descSep style) descs) <<+>> mv
       show_opt
         | optVisibility opt == Hidden
         = descHidden style

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -117,6 +117,8 @@ data ParserPrefs = ParserPrefs
                                   -- subcommand fails (default: Backtrack)
   , prefColumns :: Int            -- ^ number of columns in the terminal, used to
                                   -- format the help page (default: 80)
+  , prefLongEquals :: Bool        -- ^ If true, display usage and help information
+                                  -- using an '=' sign for long names.
   } deriving (Eq, Show)
 
 data OptName = OptShort !Char

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -117,8 +117,9 @@ data ParserPrefs = ParserPrefs
                                   -- subcommand fails (default: Backtrack)
   , prefColumns :: Int            -- ^ number of columns in the terminal, used to
                                   -- format the help page (default: 80)
-  , prefLongEquals :: Bool        -- ^ If true, display usage and help information
-                                  -- using an '=' sign for long names.
+  , prefHelpLongEquals :: Bool    -- ^ when displaying long names in usage and help,
+                                  -- use an '=' sign for long names, rather than a
+                                  -- single space (default: False)
   } deriving (Eq, Show)
 
 data OptName = OptShort !Char

--- a/tests/long_equals.err.txt
+++ b/tests/long_equals.err.txt
@@ -1,0 +1,6 @@
+Usage: long_equals (-i|-j|--intval=|--intval2=ARG)
+
+Available options:
+  -i,-j,--intval=,--intval2=ARG
+                           integer value
+  -h,--help                Show this help text

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -201,6 +201,17 @@ prop_nested_optional_help = once $
       i = info (p <**> helper) idm
   in checkHelpText "nested_optional" i ["--help"]
 
+prop_long_equals :: Property
+prop_long_equals = once $
+  let p :: Parser String
+      p = option auto (long "intval"
+                       <> short 'j'
+                       <> long "intval2"
+                       <> short 'i'
+                       <> help "integer value")
+      i = info (p <**> helper) fullDesc
+  in checkHelpTextWith ExitSuccess (prefs helpLongEquals) "long_equals" i ["--help"]
+
 prop_nested_fun :: Property
 prop_nested_fun = once $
   let p :: Parser (String, Maybe (String, Maybe String))


### PR DESCRIPTION
Added a `prefHelpLongEquals` preference modifier that displays equals signs for long options rather than spaces. Does not affect the behavior of the parser; it's purely a cosmetic alteration in terms of how the help and usage info are rendered. Have not yet tested this thoroughly, but it seems to look fine for all the obvious cases.

I did this in the most sensible way I could think of -- basically, all the long names are displayed with equals signs even if there are multiple long names, so `-l|--long1=|--long2=ARG` is how it would be displayed if you had one short and two long, for example. The way we detect whether to use an equals sign is by checking the `ParserPrefs` argument along with ensuring that the option actually takes a value (which, in turn, is determined by checking whether the metavariable is a `Chunk Just _` or a `Chunk Nothing`).