### PR TITLE
Update for GHC 8.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
  - GHCVER=8.2.1
  - GHCVER=8.4.1
  - GHCVER=8.6.3
+ - GHCVER=8.8.1
  - GHCVER=head
 
 matrix:
@@ -27,6 +28,6 @@ script:
  - export VERSION=$(cabal info . | awk 'NR==1 { n=split($2,x,"-"); print x[n]; }')
  - cabal install --only-dependencies --enable-tests
  - |
-   if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "8.6" ] || [ ${GHCVER%.*} = "8.4" ] || [ ${GHCVER%.*} = "8.2" ] || [ ${GHCVER%.*} = "8.0" ] || [ ${GHCVER%.*} = "7.10" ] || [ ${GHCVER%.*} = "7.8" ] || [ ${GHCVER%.*} = "7.6" ] || [ ${GHCVER%.*} = "7.4" ] ; then
+   if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "8.8" ] || [ ${GHCVER%.*} = "8.6" ] || [ ${GHCVER%.*} = "8.4" ] || [ ${GHCVER%.*} = "8.2" ] || [ ${GHCVER%.*} = "8.0" ] || [ ${GHCVER%.*} = "7.10" ] || [ ${GHCVER%.*} = "7.8" ] || [ ${GHCVER%.*} = "7.6" ] || [ ${GHCVER%.*} = "7.4" ] ; then
       cabal test
    fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 0.15.0.0
+
+- No longer supply `fail` method for `ReadM` monad; instead supply
+  it via the `MonadFail` class.
+
 ## Version 0.14.3.0 (03 Oct 2018)
 
 - Updated dependency bounds.

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -184,7 +184,6 @@ instance Alternative ReadM where
 instance Monad ReadM where
   return = pure
   ReadM r >>= f = ReadM $ r >>= unReadM . f
-  fail = Fail.fail
 
 instance Fail.MonadFail ReadM where
   fail = readerError

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -1,5 +1,5 @@
 name:                optparse-applicative
-version:             0.14.3.0
+version:             0.15.0.0
 synopsis:            Utilities and combinators for parsing command line options
 description:
     optparse-applicative is a haskell library for parsing options


### PR DESCRIPTION
This updates `optparse-applicative` for GHC 8.8.1. Doing so without CPP in the main library requires removing a `fail` method from the `Monad` class.