### PR TITLE
Allow semigroups-0.19 and fix Monad(fail)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
  - GHCVER=8.2.1
  - GHCVER=8.4.1
  - GHCVER=8.6.3
+ - GHCVER=8.8.1
  - GHCVER=head
 
 matrix:
@@ -16,8 +17,8 @@ matrix:
 before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-1.24 ghc-$GHCVER happy-1.19.5 alex-3.1.7
- - export PATH=/opt/alex/3.1.7/bin:/opt/happy/1.19.5/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/1.24/bin:$HOME/.cabal/bin:$PATH
+ - travis_retry sudo apt-get install cabal-install-2.4 ghc-$GHCVER happy-1.19.5 alex-3.1.7
+ - export PATH=/opt/alex/3.1.7/bin:/opt/happy/1.19.5/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/2.4/bin:$HOME/.cabal/bin:$PATH
 
 install:
  - /bin/true
@@ -27,6 +28,6 @@ script:
  - export VERSION=$(cabal info . | awk 'NR==1 { n=split($2,x,"-"); print x[n]; }')
  - cabal install --only-dependencies --enable-tests
  - |
-   if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "8.6" ] || [ ${GHCVER%.*} = "8.4" ] || [ ${GHCVER%.*} = "8.2" ] || [ ${GHCVER%.*} = "8.0" ] || [ ${GHCVER%.*} = "7.10" ] || [ ${GHCVER%.*} = "7.8" ] || [ ${GHCVER%.*} = "7.6" ] || [ ${GHCVER%.*} = "7.4" ] ; then
+   if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "8.8" ] || [ ${GHCVER%.*} = "8.6" ] || [ ${GHCVER%.*} = "8.4" ] || [ ${GHCVER%.*} = "8.2" ] || [ ${GHCVER%.*} = "8.0" ] || [ ${GHCVER%.*} = "7.10" ] || [ ${GHCVER%.*} = "7.8" ] || [ ${GHCVER%.*} = "7.6" ] || [ ${GHCVER%.*} = "7.4" ] ; then
       cabal test
    fi

--- a/Options/Applicative/Types.hs
+++ b/Options/Applicative/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Rank2Types, ExistentialQuantification #-}
+{-# LANGUAGE CPP, Rank2Types, ExistentialQuantification #-}
 module Options.Applicative.Types (
   ParseError(..),
   ParserInfo(..),
@@ -184,7 +184,10 @@ instance Alternative ReadM where
 instance Monad ReadM where
   return = pure
   ReadM r >>= f = ReadM $ r >>= unReadM . f
+
+#if !(MIN_VERSION_base(4,13,0))
   fail = Fail.fail
+#endif
 
 instance Fail.MonadFail ReadM where
   fail = readerError

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -52,7 +52,9 @@ library
 
   -- See https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#base-4.9.0.0
   if impl(ghc >= 8.0)
-    ghc-options:  -Wno-redundant-constraints -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+    ghc-options:  -Wno-redundant-constraints -Wcompat -Wnoncanonical-monad-instances
+    if impl(ghc < 8.8)
+      ghc-options: -Wnoncanonical-monadfail-instances
 
   exposed-modules:     Options.Applicative
                      , Options.Applicative.Arrows
@@ -78,7 +80,7 @@ library
                      , ansi-wl-pprint                  >= 0.6.8 && < 0.7
 
   if !impl(ghc >= 8)
-    build-depends:     semigroups                      >= 0.10 && < 0.19
+    build-depends:     semigroups                      >= 0.10 && < 0.20
                      , fail                            == 4.9.*
 
 test-suite tests
@@ -100,7 +102,7 @@ test-suite tests
   build-depends:       base
                      , bytestring                      == 0.10.*
                      , optparse-applicative
-                     , QuickCheck                      >= 2.8 && < 2.13
+                     , QuickCheck                      >= 2.8 && < 2.14
 
   if !impl(ghc >= 8)
     build-depends:     semigroups


### PR DESCRIPTION
- semigroups-0.19 doesn't break anything in optparse-applicative
- fail isn't a method of Monad since base-4.13 (GHC-8.8)
  - Also the warning is removed, as it says
    -Wnoncanonical-monadfail-instances is deprecated: fail is no longer a method of Monad

This is superset of https://github.com/pcapriotti/optparse-applicative/pull/339

I'd also recommend using [`haskell-ci`](https://github.com/haskell-CI/haskell-ci) for generating .travis.yml; I'll do a separate PR with it.