### PR TITLE
bash, readline default comp-options

### DIFF
--- a/src/Options/Applicative/BashCompletion.hs
+++ b/src/Options/Applicative/BashCompletion.hs
@@ -176,7 +176,7 @@ bashCompletionScript prog progn = return
   , "    COMPREPLY=( $(" ++ prog ++ " \"${CMDLINE[@]}\") )"
   , "}"
   , ""
-  , "complete -o filenames -F _" ++ progn ++ " " ++ progn ]
+  , "complete -o bashdefault -o default -F _" ++ progn ++ " " ++ progn ]
 
 {-
 /Note/: Fish Shell


### PR DESCRIPTION
In cases where no completion candidates are generated by the registered completion function, fallback to the default completions provided by bash (`-o bashdefault`) and readline (`-o default`).

___
This may or may not be desirable. When building a parser that allows miscellaneous trailing arguments, it allows the usual filename and directory completion to occur when entering those arguments. For example,
```sh
my-cli run --verbose -- foo.txt bar.hs baz/qux.hi
```

The downside is that this makes the completion logic more permissive than the parser itself in some cases. For example, if the above `my-cli` program expects either a `run` or `list` command, typing
```
my-cli <Tab><Tab>
```
will correctly suggest `run` and `list`, but if you type something that cannot complete to a valid command and _can_ complete to a filename, bash will happily fill that it.

I put this together while attempting to address the trailing args use-case, but now that I better understand the problem with this overly permissive approach, I put the PR up mostly to get feedback/suggestions for a better solution. I took a look at [bashCompleter](https://hackage.haskell.org/package/optparse-applicative-0.14.3.0/docs/Options-Applicative.html#v:bashCompleter) and [mkCompleter](https://hackage.haskell.org/package/optparse-applicative-0.14.3.0/docs/Options-Applicative.html#v:mkCompleter) but haven't yet found a way to hook into bash+readline default completions.

___

Testing notes:
```sh
mkdir tmp
PATH=$PWD/tmp:$PATH
ghc --make fnord.hs -o tmp/fnord

# upstream completions
. <(fnord --bash-completion-script fnord)

# completions with bash+readline fallbacks
. <(fnord --bash-completion-script fnord |
    sed 's/ -o filenames / -o bashdefault -o default /')
```
with the following `fnord.hs`
```haskell
module Main where

import Options.Applicative
import Data.Semigroup ((<>))


data CmdLine
  = Exec String
  | List String
  deriving Show


main :: IO ()
main =
    execParser (info cmdline mempty) >>= print
  where
    cmdline :: Parser CmdLine
    cmdline = subparser
        ( command "exec" (info (Exec <$> arg) mempty)
       <> command "list" (info (List <$> arg) mempty) )

    arg :: Parser String
    arg = strArgument mempty
```