### PR TITLE
Use softline instead of space to append default value to help

### DIFF
--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -150,7 +150,7 @@ fullDesc pprefs = tabulate . catMaybes . mapParser doc
     doc info opt = do
       guard . not . isEmpty $ n
       guard . not . isEmpty $ h
-      return (extractChunk n, align . extractChunk $ h <<+>> hdef)
+      return (extractChunk n, align . extractChunk $ h <</>> hdef)
       where
         n = fst $ optDesc pprefs style info opt
         h = optHelp opt


### PR DESCRIPTION
This enables long default values to wrap correctly. Otherwise, the
last word of the help text always wraps with the default value.

Closes #350

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pcapriotti/optparse-applicative/361)
<!-- Reviewable:end -->
