### PR TITLE
Topic/multi suffix generalisation

### DIFF
--- a/src/Options/Applicative/BashCompletion.hs
+++ b/src/Options/Applicative/BashCompletion.hs
@@ -91,7 +91,7 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
     --
     -- For options and flags, ensure that the user
     -- hasn't disabled them with `--`.
-    opt_completions argPolicy hinfo opt = case optMain opt of
+    opt_completions argPolicy reachability opt = case optMain opt of
       OptReader ns _ _
          | argPolicy /= AllPositionals
         -> return . add_opt_help opt $ show_names ns
@@ -103,12 +103,12 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
          | otherwise
         -> return []
       ArgReader rdr
-         | hinfoUnreachableArgs hinfo
+         | argumentIsUnreachable reachability
         -> return []
          | otherwise
         -> run_completer (crCompleter rdr)
       CmdReader _ ns p
-         | hinfoUnreachableArgs hinfo
+         | argumentIsUnreachable reachability
         -> return []
          | otherwise
         -> return . add_cmd_help p $ filter_names ns

--- a/src/Options/Applicative/Common.hs
+++ b/src/Options/Applicative/Common.hs
@@ -249,32 +249,32 @@ mapParser f = flatten . treeMapParser f
     flatten (Leaf x) = [x]
     flatten (MultNode xs) = xs >>= flatten
     flatten (AltNode _ xs) = xs >>= flatten
+    flatten (BindNode x) = flatten x
 
 -- | Like 'mapParser', but collect the results in a tree structure.
 treeMapParser :: (forall x . OptHelpInfo -> Option x -> b)
           -> Parser a
           -> OptTree b
-treeMapParser g = simplify . go False False g
+treeMapParser g = simplify . go False g
   where
     has_default :: Parser a -> Bool
     has_default p = isJust (evalParser p)
 
     go :: Bool
-       -> Bool
        -> (forall x . OptHelpInfo -> Option x -> b)
        -> Parser a
        -> OptTree b
-    go _ _ _ (NilP _) = MultNode []
-    go m r f (OptP opt)
+    go _ _ (NilP _) = MultNode []
+    go r f (OptP opt)
       | optVisibility opt > Internal
-      = Leaf (f (OptHelpInfo m r) opt)
+      = Leaf (f (OptHelpInfo r) opt)
       | otherwise
       = MultNode []
-    go m r f (MultP p1 p2) =
-      MultNode [go m r f p1, go m r' f p2]
+    go r f (MultP p1 p2) =
+      MultNode [go r f p1, go r' f p2]
       where r' = r || hasArg p1
-    go m r f (AltP p1 p2) =
-      AltNode altNodeType [go m r f p1, go m r f p2]
+    go r f (AltP p1 p2) =
+      AltNode altNodeType [go r f p1, go r f p2]
       where
         -- The 'AltNode' indicates if one of the branches has a default.
         -- This is used for rendering brackets, as well as filtering
@@ -284,11 +284,11 @@ treeMapParser g = simplify . go False False g
             then MarkDefault
             else NoDefault
 
-    go _ r f (BindP p k) =
-      let go' = go True r f p
+    go r f (BindP p k) =
+      let go' = go r f p
       in case evalParser p of
-        Nothing -> go'
-        Just aa -> MultNode [ go', go True r f (k aa) ]
+        Nothing -> BindNode (go')
+        Just aa -> BindNode (MultNode [ go', go r f (k aa) ])
 
     hasArg :: Parser a -> Bool
     hasArg (NilP _) = False
@@ -312,3 +312,5 @@ simplify (AltNode b xs) =
     remove_alt (AltNode _ ts) = ts
     remove_alt (MultNode []) = []
     remove_alt t = [t]
+simplify (BindNode x) =
+  BindNode $ simplify x

--- a/src/Options/Applicative/Extra.hs
+++ b/src/Options/Applicative/Extra.hs
@@ -257,11 +257,11 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
             -- things the user could type. If it's a command
             -- reader also ensure that it can be immediately
             -- reachable from where the error was given.
-            opt_completions hinfo opt = case optMain opt of
+            opt_completions reachability opt = case optMain opt of
               OptReader ns _ _ -> fmap showOption ns
               FlagReader ns _  -> fmap showOption ns
               ArgReader _      -> []
-              CmdReader _ ns _  | hinfoUnreachableArgs hinfo
+              CmdReader _ ns _  | argumentIsUnreachable reachability
                                -> []
                                 | otherwise
                                -> ns

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -28,7 +28,7 @@ module Options.Applicative.Types (
   overFailure,
   Args,
   ArgPolicy(..),
-  OptHelpInfo(..),
+  ArgumentReachability(..),
   AltNodeType(..),
   OptTree(..),
   ParserHelp(..),
@@ -392,9 +392,9 @@ data ArgPolicy
   --   but are supplying just a few of their own options.
   deriving (Eq, Ord, Show)
 
-data OptHelpInfo = OptHelpInfo
-  { hinfoUnreachableArgs :: Bool -- ^ If the result is a positional, if it can't be
-                                 --   accessed in the current parser position ( first arg )
+newtype ArgumentReachability = ArgumentReachability
+  { argumentIsUnreachable :: Bool -- ^ If the result is a positional, if it can't be
+                                  --    accessed in the current parser position ( first arg )
   } deriving (Eq, Show)
 
 -- | This type encapsulates whether an 'AltNode' of an 'OptTree' should be displayed

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -393,8 +393,7 @@ data ArgPolicy
   deriving (Eq, Ord, Show)
 
 data OptHelpInfo = OptHelpInfo
-  { hinfoMulti :: Bool           -- ^ Whether this is part of a many or some (approximately)
-  , hinfoUnreachableArgs :: Bool -- ^ If the result is a positional, if it can't be
+  { hinfoUnreachableArgs :: Bool -- ^ If the result is a positional, if it can't be
                                  --   accessed in the current parser position ( first arg )
   } deriving (Eq, Show)
 
@@ -407,6 +406,7 @@ data OptTree a
   = Leaf a
   | MultNode [OptTree a]
   | AltNode AltNodeType [OptTree a]
+  | BindNode (OptTree a)
   deriving Show
 
 filterOptional :: OptTree a -> OptTree a
@@ -419,6 +419,8 @@ filterOptional t = case t of
     -> AltNode MarkDefault []
   AltNode NoDefault xs
     -> AltNode NoDefault (map filterOptional xs)
+  BindNode xs
+    -> BindNode (filterOptional xs)
 
 optVisibility :: Option a -> OptVisibility
 optVisibility = propVisibility . optProps

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -24,6 +24,8 @@ import           Test.QuickCheck.Property
 
 import           Options.Applicative
 import           Options.Applicative.Types
+
+import qualified Options.Applicative.Help as H
 import           Options.Applicative.Help.Pretty (Doc, SimpleDoc(..))
 import qualified Options.Applicative.Help.Pretty as Doc
 import           Options.Applicative.Help.Chunk
@@ -771,6 +773,84 @@ prop_bytestring_reader = once $
       i = info p idm
       result = run i ["testValue"]
   in assertResult result $ \xs -> BS8.pack t === xs
+
+prop_grouped_some_option_ellipsis :: Property
+prop_grouped_some_option_ellipsis = once $
+  let x :: Parser String
+      x = strOption (short 'x' <> metavar "X")
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p (x *> some x)
+  in r === "-x X (-x X)..."
+
+prop_grouped_many_option_ellipsis :: Property
+prop_grouped_many_option_ellipsis = once $
+  let x :: Parser String
+      x = strOption (short 'x' <> metavar "X")
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p (x *> many x)
+  in r === "-x X [-x X]..."
+
+prop_grouped_some_argument_ellipsis :: Property
+prop_grouped_some_argument_ellipsis = once $
+  let x :: Parser String
+      x = strArgument (metavar "X")
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p (x *> some x)
+  in r === "X X..."
+
+prop_grouped_many_argument_ellipsis :: Property
+prop_grouped_many_argument_ellipsis = once $
+  let x :: Parser String
+      x = strArgument (metavar "X")
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p (x *> many x)
+  in r === "X [X]..."
+
+prop_grouped_some_pairs_argument_ellipsis :: Property
+prop_grouped_some_pairs_argument_ellipsis = once $
+  let x :: Parser String
+      x = strArgument (metavar "X")
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p (x *> some (x *> x))
+  in r === "X (X X)..."
+
+prop_grouped_many_pairs_argument_ellipsis :: Property
+prop_grouped_many_pairs_argument_ellipsis = once $
+  let x :: Parser String
+      x = strArgument (metavar "X")
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p (x *> many (x *> x))
+  in r === "X [X X]..."
+
+prop_grouped_some_dual_option_ellipsis :: Property
+prop_grouped_some_dual_option_ellipsis = once $
+  let x :: Parser String
+      x = strOption (short 'a' <> short 'b' <> metavar "X")
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p (x *> some x)
+  in r === "(-a|-b X) (-a|-b X)..."
+
+prop_grouped_many_dual_option_ellipsis :: Property
+prop_grouped_many_dual_option_ellipsis = once $
+  let x :: Parser String
+      x = strOption (short 'a' <> short 'b' <> metavar "X")
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p (x *> many x)
+  in r === "(-a|-b X) [-a|-b X]..."
+
+prop_grouped_some_dual_flag_ellipsis :: Property
+prop_grouped_some_dual_flag_ellipsis = once $
+  let x = flag' () (short 'a' <> short 'b')
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p (x *> some x)
+  in r === "(-a|-b) (-a|-b)..."
+
+prop_grouped_many_dual_flag_ellipsis :: Property
+prop_grouped_many_dual_flag_ellipsis = once $
+  let x = flag' () (short 'a' <> short 'b')
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p (x *> many x)
+  in r === "(-a|-b) [-a|-b]..."
 
 ---
 


### PR DESCRIPTION
Allows suffixes for multi arguments to be applied to groups of arguments, addressing #362 .

As an indication, things like this ` (-a|-b)...` are now possible.

This one's a bit subtle in its implementation.

@crocket 