### PR TITLE
Allow --help to take as an argument a command name.

### DIFF
--- a/src/Options/Applicative/Common.hs
+++ b/src/Options/Applicative/Common.hs
@@ -206,8 +206,7 @@ runParser policy _ p ("--" : argt) | policy /= AllPositionals
 runParser policy isCmdStart p args = case args of
   [] -> exitP isCmdStart policy p result
   (arg : argt) -> do
-    prefs <- getPrefs
-    (mp', args') <- do_step prefs arg argt
+    (mp', args') <- do_step arg argt
     case mp' of
       Nothing -> hoistMaybe result <|> parseError arg p
       Just p' -> runParser (newPolicy arg) CmdCont p' args'
@@ -221,9 +220,10 @@ runParser policy isCmdStart p args = case args of
       NoIntersperse -> if isJust (parseWord a) then NoIntersperse else AllPositionals
       x             -> x
 
-runParserStep :: MonadP m => ArgPolicy -> Parser a -> ParserPrefs -> String -> Args -> m (Maybe (Parser a), Args)
-runParserStep policy p prefs arg =
-  runStateT
+runParserStep :: MonadP m => ArgPolicy -> Parser a -> String -> Args -> m (Maybe (Parser a), Args)
+runParserStep policy p arg args = do
+  prefs <- getPrefs
+  flip runStateT args
     $ disamb (not (prefDisambiguate prefs))
     $ stepParser prefs policy arg p
 

--- a/src/Options/Applicative/Extra.hs
+++ b/src/Options/Applicative/Extra.hs
@@ -169,10 +169,9 @@ parserFailure pprefs pinfo msg ctx0 = ParserFailure $ \progn ->
             , error_help ]
   in (h, exit_code, prefColumns pprefs)
   where
-    -- If the error is a help command with a sub-command as an argument we want to
-    -- try and display the sub-command's help text instead.
-    -- We try to take a parse step with the argument to --help, gathering just the
-    -- new context that might be found, and add it to the original contexts.
+    --
+    -- Add another context layer if the argument to --help is
+    -- a valid command.
     ctx = case msg of
       ShowHelpText (Just potentialCommand) ->
         let ctx1 = with_context ctx0 pinfo $ \_ pinfo' ->

--- a/src/Options/Applicative/Extra.hs
+++ b/src/Options/Applicative/Extra.hs
@@ -182,7 +182,7 @@ parserFailure pprefs pinfo msg ctx0 = ParserFailure $ \progn ->
               (runParserStep (infoPolicy pinfo) (infoParser pinfo) pprefs potentialCommand [])
               pprefs
         in
-          ctx1 <> ctx0
+          ctx1 `mappend` ctx0
       _ ->
         ctx0
 

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -68,7 +68,7 @@ import Options.Applicative.Help.Chunk
 data ParseError
   = ErrorMsg String
   | InfoMsg String
-  | ShowHelpText
+  | ShowHelpText (Maybe String)
   | UnknownError
   | MissingError IsCmdStart SomeParser
   | ExpectsArgError String

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -299,8 +299,8 @@ someM p = (:) <$> oneM p <*> manyM p
 instance Alternative Parser where
   empty = NilP Nothing
   (<|>) = AltP
-  many p = fromM $ manyM p
-  some p = fromM $ (:) <$> oneM p <*> manyM p
+  many = fromM . manyM
+  some = fromM . someM
 
 -- | A shell complete function.
 newtype Completer = Completer

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -862,7 +862,6 @@ prop_nice_some1 = once $
       r = show . extractChunk $ H.briefDesc p x
   in r === "(-a)..."
 
-
 prop_some1_works :: Property
 prop_some1_works = once $
   let p = Options.Applicative.NonEmpty.some1 (flag' () (short 'a'))
@@ -870,7 +869,31 @@ prop_some1_works = once $
       result = run i ["-a", "-a"]
   in assertResult result $ \xs -> () :| [()] === xs
 
+prop_help_contexts :: Property
+prop_help_contexts = once $
+  let
+    grabHelpMessage (Failure failure) =
+      let (msg, ExitSuccess) = renderFailure failure "<text>"
+      in msg
+    grabHelpMessage _ = error "Parse did not render help text"
 
+    i = Cabal.pinfo
+    pre = run i ["install", "--help"]
+    post = run i ["--help", "install"]
+  in grabHelpMessage pre === grabHelpMessage post
+
+prop_help_unknown_context :: Property
+prop_help_unknown_context = once $
+  let
+    grabHelpMessage (Failure failure) =
+      let (msg, ExitSuccess) = renderFailure failure "<text>"
+      in msg
+    grabHelpMessage _ = error "Parse did not render help text"
+
+    i = Cabal.pinfo
+    pre = run i ["--help"]
+    post = run i ["--help", "not-a-command"]
+  in grabHelpMessage pre === grabHelpMessage post
 
 ---
 


### PR DESCRIPTION
Allow --help to take as an argument a subcommand name. If the argument to --help is an actual subcommand, display the subcommand's help text instead.

Addressing #379 and #175 . 

CC: @shmish111 @merijn