### PR TITLE
README: updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ options, which will yield a value of type `a` when the command line
 arguments are successfully parsed.
 
 If you are familiar with parser combinator libraries like [parsec],
-[attoparsec], or the json parser [aeson] you will feel right at
+[attoparsec], or the JSON parser [aeson] you will feel right at
 home with optparse-applicative.
 
 If not, don't worry! All you really need to learn are a few basic

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ containing a detailed list of options with descriptions
 ### Parsers
 
 optparse-applicative provides a number of primitive parsers,
-corresponding to different posix style options, through its *Builder*
+corresponding to different POSIX style options, through its *Builder*
 interface. These are detailed in their [own section](#builders)
 below, for now, here's a look at a few more examples to get a feel
 for how parsers can be defined.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The attributes passed to the option are called *modifiers*, and are
 composed using the [semigroup] operation `(<>)`.
 
 Options with an argument such as `target` are referred to as *regular
-options*, and are very common.  Another type of option is a *flag*,
+options*, and are very common. Another type of option is a *flag*,
 the simplest of which is a Boolean *switch*, for example:
 
 ```haskell

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ sample = Sample
 
 The parser is built using an [applicative] style starting from a
 set of basic combinators. In this example, hello is defined as an
-option with a `String` argument, while quiet is a boolean flag
+option with a `String` argument, while quiet is a Boolean flag
 (called a switch) and enthusiasm gets parsed as an `Int` with help
 of the `Read` type class.
 
@@ -189,7 +189,7 @@ composed using the [semigroup] operation `(<>)`.
 
 Options with an argument such as `target` are referred to as *regular
 options*, and are very common.  Another type of option is a *flag*,
-the simplest of which is a boolean *switch*, for example:
+the simplest of which is a Boolean *switch*, for example:
 
 ```haskell
 quiet :: Parser Bool
@@ -463,7 +463,7 @@ flag Normal Verbose
 
 is a flag parser returning a `Verbosity` value.
 
-Simple boolean flags can be specified using the `switch` builder, like so:
+Simple Boolean flags can be specified using the `switch` builder, like so:
 
 ```haskell
 switch

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ above will require an option like
 
     --hello world
 
-on the command line. The metavariable and the help text will appear
+on the command line. The `help` and `metavar` text will appear
 in the generated help text, but don't otherwise affect the behaviour
 of the parser.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for composing them.
 optparse-applicative takes care of reading and validating the
 arguments passed to the command line, handling and reporting errors,
 generating a usage line, a comprehensive help screen, and enabling
-context-sensitive bash, zsh, and fish completions.
+context-sensitive `bash`, `zsh`, and `fish` completions.
 
 **Table of Contents**
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ quiet = switch ( long "quiet" <> short 'q' <> help "Whether to be quiet" )
 ```
 
 Here we used a `short` modifier to specify a one-letter name for
-the option. This means that this switch can be set either with
+the option.  This means that this switch can be set either with
 `--quiet` or `-q`.
 
 Flags, unlike regular options, have no arguments. They simply return

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ a predetermined value. For the simple switch above, this is `True`
 if the user types the flag, and `False` otherwise.
 
 There are other kinds of basic parsers, and several ways to configure
-them.  These are covered in the [Builders](#builders) section.
+them. These are covered in the [Builders](#builders) section.
 
 ### Applicative
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ optparse-applicative is a Haskell library for parsing options on
 the command line, and providing a powerful [applicative] interface
 for composing them.
 
-optparse-applicative takes care of reading and validating the
-arguments passed to the command line, handling and reporting errors,
-generating a usage line, a comprehensive help screen, and enabling
-context-sensitive `bash`, `zsh`, and `fish` completions.
+optparse-applicative is created to:
+  - read and validate the arguments passed to the command line;
+  - handle and report errors;
+  - generate lines that explain usage;
+  - have a comprehensive help screen;
+  - create context-sensitive complettions for `bash`, `zsh`, `fish`.
 
 **Table of Contents**
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ target = strOption
   <> help "Target for the greeting" )
 ```
 
-This defines an option parser with the *long* shell option type,
+This defines an option parser. That has only the *long* key,
 named "hello" (resulting in `--hello`).
 It assepts a `String` as an argument, which would be marked by its
 *metavariable* "TARGET" in the documentations.

--- a/README.md
+++ b/README.md
@@ -158,8 +158,7 @@ containing a detailed list of options with descriptions
 
 optparse-applicative provides a number of primitive parsers,
 corresponding to different POSIX style options, through its *Builder*
-interface. These are detailed in their [own section](#builders)
-below, for now, here's a look at a few more examples to get a feel
+interface. Please attend to a few more examples to get a feel
 for how parsers can be defined.
 
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ quiet = switch ( long "quiet" <> short 'q' <> help "Whether to be quiet" )
 ```
 
 Here we used a `short` modifier to specify a one-letter name for
-the option.  This means that this switch can be set either with
+the option. This means that this switch can be set either with
 `--quiet` or `-q`.
 
 Flags, unlike regular options, have no arguments. They simply return

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ quiet = switch ( long "quiet" <> short 'q' <> help "Whether to be quiet" )
 ```
 
 Here we used a `short` modifier to specify a one-letter name for
-the option.  This means that this switch can be set either with
+the option. This means that this switch can be set either with
 `--quiet` or `-q`.
 
 Flags, unlike regular options, have no arguments. They simply return

--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ target = strOption
   <> help "Target for the greeting" )
 ```
 
-One can see that we are defining an option parser for a `String`
-argument, with *long* option name "hello", *metavariable* "TARGET",
+This defines an option parser that assepts a `String` argument,
+with *long* option name "hello", *metavariable* "TARGET",
 and the given help text. This means that the `target` parser defined
 above will require an option like
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If not, don't worry! All you really need to learn are a few basic
 parsers, and how to compose them as instances of `Applicative` and
 `Alternative`.
 
-## Quick Start
+## Quick start
 
 Here's a simple example of a parser.
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,8 @@ quiet :: Parser Bool
 quiet = switch ( long "quiet" <> short 'q' <> help "Whether to be quiet" )
 ```
 
-Here we used a `short` modifier to specify a one-letter name for
-the option. This means that this switch can be set either with
-`--quiet` or `-q`.
+`short` modifier specifies a one-letter name for the option.
+This means that this switch can be set either with `--quiet` or `-q`.
 
 Flags, unlike regular options, have no arguments. They simply return
 a predetermined value. For the simple switch above, this is `True`

--- a/README.md
+++ b/README.md
@@ -172,10 +172,12 @@ target = strOption
   <> help "Target for the greeting" )
 ```
 
-This defines an option parser that assepts a `String` argument,
-with *long* option name "hello", *metavariable* "TARGET",
-and the given help text. This means that the `target` parser defined
-above will require an option like
+This defines an option parser with the *long* shell option type,
+named "hello" (resulting in `--hello`).
+It assepts a `String` as an argument, which would be marked by its
+*metavariable* "TARGET" in the documentations.
+Help message provides the description.
+So result works like:
 
     --hello world
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ above will require an option like
 
     --hello world
 
-on the command line. The `help` and `metavar` text will appear
+on the command line. The `help` and `metavar` values will appear
 in the generated help text, but don't otherwise affect the behaviour
 of the parser.
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ composed using the [semigroup] operation `(<>)`.
 
 Options with an argument such as `target` are referred to as *regular
 options*, and are very common. Another type of option is a *flag*,
-the simplest of which is a Boolean *switch*, for example:
+the simplest of which is a Boolean *switch*. Example:
 
 ```haskell
 quiet :: Parser Bool

--- a/README.md
+++ b/README.md
@@ -181,9 +181,8 @@ So result works like:
 
     --hello world
 
-on the command line. The `help` and `metavar` values going to appear
-in the generated help text, but don't otherwise affect the behaviour
-of the parser.
+The `help` and `metavar` values going to appear in the generated help
+text, but don't otherwise affect the behaviour of the parser.
 
 The attributes passed to the option are called *modifiers*, and are
 composed using the [semigroup] operation `(<>)`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Hackage page (downloads and API reference)][hackage-png]][hackage]
 [![Hackage-Deps][hackage-deps-png]][hackage-deps]
 
-optparse-applicative is a haskell library for parsing options on
+optparse-applicative is a Haskell library for parsing options on
 the command line, and providing a powerful [applicative] interface
 for composing them.
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ above will require an option like
 
     --hello world
 
-on the command line. The `help` and `metavar` values will appear
+on the command line. The `help` and `metavar` values going to appear
 in the generated help text, but don't otherwise affect the behaviour
 of the parser.
 

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ So result works like:
 
     --hello world
 
-The `help` and `metavar` values going to appear in the generated help
-text, but don't otherwise affect the behaviour of the parser.
+
+The `help` and `metavar` do not affect the parser, only documentation.
 
 The attributes passed to the option are called *modifiers*, and are
 composed using the [semigroup] operation `(<>)`.


### PR DESCRIPTION
Ok. I would stop. Because here we have these options:

1. I can continue pointlessly and I would never be able to make you accept a lot of changes.
2. Do an epic back&forth commit/rebase/review amount of work and cycles.
3. Do a major rewrite.

None of these options are of a effective effort in a situation when a contributor needs to squeeze through PR & review process.

---

#### Manual line wrapping as a problem

I understand 80 char lines in the Haskell code. But I do not understand why people apply the programming style in the structured programming code as an argument to the text information that people read through linearly.

Markdown is textual document editing, lets look at other cases of document editing - we are not line-breaking manually in the Office docs or in LaTeX/PDF publications nor in books or in newspapers.

Technical arguments I would refute with that today even in the Linux Kernel Console (specific type of terminal (when `$TERM == console`) - even there line/word wrap happens by the usage of even direct `stdout` into the device of the virtual terminal, line wrapping also happens in `cat` or `less` and any sane editor allows to toggle wrapping. One *needs* to work and search really thoroughly to construct some very esoteric case to try to build a statement that manual line wrapping in markdown is useful for some technical reason.

Quite the contrary - due to constant manual line wrapping in the text - every atomic commit in the documentation needs to become not atomic. Any change needs to align multiple lines below it. So commit then becomes not atomic, they become interdependent because they overlap on each other constantly.

On the other side - reading. The proper phrasing and relying on line-wrapping. 
1. Anyway, most of thoughtful condensed lines and statements are smaller than 80 chars.
2. If a paragraph is long - automatic wrapping OR no wrapping in IDE motivates to make it concise or split in simpler paragraphs.
3. Manual wrapping has the acceptance of long paragraphs - which indeed results in longer paragraphs.  With means less concise info and complexity of reading long paragraphs - and results in lower readability and so comprehension. And remember - they are harder to edit and pass review - so you get the lock-in, documentation stops evolving. And it also makes adding more documentation way easier - then to refactor through PRs already written documentation that is the manually wrapped.
4. Relying on automatic line wrapping gives documentation in the editor in the first style:
```

Empty lines are between here because every line is a markdown paragraph.

Even lines may be longer. They are very readable.

Because of this separation of long lines vertically with empty lines.

It allows to read them much more easily than the crowded writing.

And so makes easy to draw attention to every word of it.

```

```
Before example reads much easier than this one,
due to this text lacks vertical separation space.
And this text seems crowded and I see words on lines
Above and below when I am reading such text,
and that distracts more.
```

And all lines come-out of different length anyway - so it looks and feels very rustic anyway.

So I do not see why to do manual line wrapping - it produces and complicates the work, I do not see the gains in it - an additional effort put that only sacrifices from the usability and ease of the important - work, and readability in the IDE.

##### What it resolves into

So I can not keep a promise of delivering fully atomic commits that you can cherry-pick, due to the prior practice in the document of the manual line wrap.

And I can not deliver the big pull request, because I would do major work which would be pointless - you would probably not accept a major rewrite and you would need to discern all out manual line wrapping in diffs instead of looking at actual changes or make line wrapping manually after my changes. Or we would spend a LOT of effort going through it, and painfully rebasing overlapping commits on every change requested & rebase - it would take weeks if not month of back and forth and of rebasing.

#### Restructuring: The statement

The document needs some restructuring. At least the `Basics` section.

##### Example

Basics: Parsers: inside is a talk mainly about examples, inside there is a talk mainly about builders and their attributes. But text tries to not draw attention to the builders and their types, but kinda gives links into to the builders section couple of times, but asks and expects not to use those links (maybe then not give them), or make so they are not needed (put builders before parsers) - and then link to the prior info for the person would be to easily recall info and come back down.

Lets continue further about those couple of paragraphs:

If a person ignores links and indeed continues to read - reading further in the first examples straightly talks again about builders and what they are and what types they have, and their attributes - reader is completely puzzled of what document is doing.

Again, recap: it is a parser section and talk mostly not about how parsers work, but about live examples based on builder types, and do not look at the builders section, keep attention - we are talking about builders here in the parser section.

I do not know what was the agenda of that, but that agenda already puzzled me, and I can not pay attention - because I can not create attention to the doc that does not decide what it is doing, there is a constant strange feeling that doc tries to explain some big abstractions with smaller abstractions and tries not to explain them first. Making *reductio ad absurdum*: it is if you at 6 came into math class and the teacher started to explain Calculus before multiplication.

And all that builders info there around examples in the parser is not structured in any way anyway - it just jumps from examples to them, and all done in long phrases. Person after reading those paragraphs can not name&count what builders are there in the package, but half of the talk was about them, what was the talk about parsers?

So builders info belongs to the builders section and count them for readers in a vertical list in the heading of the builders section. People would await to see the list of available types of builders before they proceed reading. That way you structure info for the reader - so then the info can be memorized by them and recalled. If you expect people to read the doc - it should be structured logically.

##### My presonal perseption

I already know something about how it works, and can construct basic cases. And I am not a stupid guy - but it is hard to read and grok the doc even in the parts where I already know how it works.

##### Ad hominem

Ad hominem ("here we have", "you can see here that we have"). Ad hominem bears zero information, it only makes phrases longer, turns pamphlets volume into a book - and the reader becomes more tired reading those, because IT guys read to get information, not constantly be reminded of who is a buddy to whom and where in virtual plane nonexistent plane what was where. If the reader gets puzzled - his attention gets wasted, and that is very unpleasant for them, and so his concentration and attention span he commits to - shortens, and it is in the age of the 3 second attention spans.

#### Restructuring: The case

If it is expected from the reader to read the doc, then doc should not give readers live examples first - because currently doc motivates to not read the doc and go code and try to understand it from practice.

But doc itself should be skimmable (aka parseable (*sic)). Haskell helps to do things the right way. If people can skim and understand the doc fast - if they have questions or issues - they would refer to it again. That is way better then no one reading it because it is too large, not skimmable and moreover puzzles them on reading.

The harder the topic is - the more organization and proper phrasing it requires to be understandable.

If there is a lot of specific terms introduced - make their definitions a separate subsection in the section. So on explanations, you would be free from switching to introducing a term. If terms itself really belong to the other section - then maybe that section needs to be delivered before the current one.

That giving examples for parsers first - resolved in the need into explaining everything else shows that or not give examples there, and then talk about parsers very generally (using associations), or place parsers when the needed info was provided above them, so the reader would be ready to understand the parser abstraction.

#### Restructuring: Proposed structure

Doc should give the reader:
  * Introduction (what library is for)
  * Data model (diagram)  -- sometimes seeing at once is better then a thousand words of explanation
  * Shortly describe where is speccing happens & belongs, where is parsing happens & belongs, where one can custom handle parsed data on top of what is provided in lib. So now readers roughly know the data model and what are structural parts and where they are
  * Attributes
    * Definitions (if there are needed)
    * Everything that is not a definition
  * Builders
    * Definitions (if there are needed)
    * Types of builders
    * How they work
    * Builder examples with different attribute combinations. Better to give primitive stuff and be safe then to sorry
  * Parsers
    * Definitions (if there are needed)
    * How parsers are composed of attributes and builders
    * Examples (if there are needed)
    * Option readers
    * Running a parser
  * Composing and more complex parsers
    * Definitions (if there are needed)
    * Applicative on parsers
      * Examples of the use of parsers in the program and how they tie with surrounding data types
    * Alternative
    * Then mention where and how to customize even over that and example
  * Error handling
  * Shell expansion
...
  * Rename "How it works" into "How library internally implemented"

That probably going to condense and simplify the doc quite to a large degree. Going from parts to the composition. Something like that.

#### Thanks

I can do more changes in reading if you accept them pretty openly, my profile is a statement that I am good at structuring [Haskell info](https://github.com/Anton-Latukha/haskell-notes/raw/master/README.pdf).

I would probably just read through it further. Big thank you from the community for this documentation. It was major work already writing such doc.
