### PR TITLE
Add builder ParserPrefs to disable global options printing

### DIFF
--- a/src/Options/Applicative/Builder.hs
+++ b/src/Options/Applicative/Builder.hs
@@ -88,6 +88,7 @@ module Options.Applicative.Builder (
   subparserInline,
   columns,
   helpLongEquals,
+  helpNoGlobals,
   prefs,
   defaultPrefs,
 
@@ -513,6 +514,11 @@ columns cols = PrefsMod $ \p -> p { prefColumns = cols }
 helpLongEquals :: PrefsMod
 helpLongEquals = PrefsMod $ \p -> p { prefHelpLongEquals = True }
 
+-- | Don't show global help information in subparser usage
+helpNoGlobals :: PrefsMod
+helpNoGlobals = PrefsMod $ \p -> p { prefHelpShowGlobal = False}
+
+
 -- | Create a `ParserPrefs` given a modifier
 prefs :: PrefsMod -> ParserPrefs
 prefs m = applyPrefsMod m base
@@ -524,7 +530,8 @@ prefs m = applyPrefsMod m base
       , prefShowHelpOnEmpty = False
       , prefBacktrack = Backtrack
       , prefColumns = 80
-      , prefHelpLongEquals = False }
+      , prefHelpLongEquals = False
+      , prefHelpShowGlobal = True }
 
 -- Convenience shortcuts
 

--- a/src/Options/Applicative/Extra.hs
+++ b/src/Options/Applicative/Extra.hs
@@ -208,7 +208,10 @@ parserFailure pprefs pinfo msg ctx0 = ParserFailure $ \progn ->
           traverse_ infoParser $
             drop 1 voided
       in
-        parserGlobals pprefs globalParsers
+        if prefHelpShowGlobal pprefs then
+          parserGlobals pprefs globalParsers
+        else
+          mempty
 
     usage_help progn names i = case msg of
       InfoMsg _

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -123,6 +123,9 @@ data ParserPrefs = ParserPrefs
   , prefHelpLongEquals :: Bool    -- ^ when displaying long names in usage and help,
                                   -- use an '=' sign for long names, rather than a
                                   -- single space (default: False)
+  , prefHelpShowGlobal :: Bool    -- ^ when displaying subparsers' usage help,
+                                  -- show parent options under a "global options"
+                                  -- section (default: True)
   } deriving (Eq, Show)
 
 data OptName = OptShort !Char
@@ -171,7 +174,7 @@ data Option a = Option
 
 data SomeParser = forall a . SomeParser (Parser a)
 
--- | Subparser context, containing the 'name' of the subparser, its parent parser, and its parser info.
+-- | Subparser context, containing the 'name' of the subparser and its parser info.
 --   Used by parserFailure to display relevant usage information when parsing inside a subparser fails.
 data Context = forall a. Context String (ParserInfo a)
 


### PR DESCRIPTION
Add a simple builder to turn off global options in the help text.

It's not strictly necessary, as one could use `overFailure` to do the same thing, but I think a few users would struggle to find that easily.