### PR TITLE
Set global options rendering off by default.

### DIFF
--- a/src/Options/Applicative.hs
+++ b/src/Options/Applicative.hs
@@ -196,6 +196,7 @@ module Options.Applicative (
   subparserInline,
   columns,
   helpLongEquals,
+  helpShowGlobals,
   defaultPrefs,
 
   -- * Completions

--- a/src/Options/Applicative/Builder.hs
+++ b/src/Options/Applicative/Builder.hs
@@ -88,7 +88,7 @@ module Options.Applicative.Builder (
   subparserInline,
   columns,
   helpLongEquals,
-  helpNoGlobals,
+  helpShowGlobals,
   prefs,
   defaultPrefs,
 
@@ -517,9 +517,9 @@ columns cols = PrefsMod $ \p -> p { prefColumns = cols }
 helpLongEquals :: PrefsMod
 helpLongEquals = PrefsMod $ \p -> p { prefHelpLongEquals = True }
 
--- | Don't show global help information in subparser usage
-helpNoGlobals :: PrefsMod
-helpNoGlobals = PrefsMod $ \p -> p { prefHelpShowGlobal = False}
+-- | Show global help information in subparser usage
+helpShowGlobals :: PrefsMod
+helpShowGlobals = PrefsMod $ \p -> p { prefHelpShowGlobal = True}
 
 
 -- | Create a `ParserPrefs` given a modifier
@@ -534,7 +534,7 @@ prefs m = applyPrefsMod m base
       , prefBacktrack = Backtrack
       , prefColumns = 80
       , prefHelpLongEquals = False
-      , prefHelpShowGlobal = True }
+      , prefHelpShowGlobal = False }
 
 -- Convenience shortcuts
 

--- a/tests/Examples/Cabal.hs
+++ b/tests/Examples/Cabal.hs
@@ -124,5 +124,5 @@ pinfo = info parser
 
 main :: IO ()
 main = do
-  r <- execParser pinfo
+  r <- customExecParser (prefs helpShowGlobals) pinfo
   print r

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -89,7 +89,7 @@ prop_cmd_header = once $
 
 prop_cabal_conf :: Property
 prop_cabal_conf = once $
-  checkHelpText "cabal" Cabal.pinfo ["configure", "--help"]
+  checkHelpTextWith ExitSuccess (prefs helpShowGlobals) "cabal" Cabal.pinfo ["configure", "--help"]
 
 prop_args :: Property
 prop_args = once $


### PR DESCRIPTION
There are a few situations where it doesn't look great,
particularly when something like a `--version` command
is set up as an alternative.

So make the global options off by default, it's backwards
compatible, and people can assess before switching it on.