### PR TITLE
Topic/internal multi

### DIFF
--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -173,9 +173,9 @@ foldTree prefs s (BindNode x) =
 
       -- We always want to display the rendered option
       -- if it exists, and only attach the suffix then.
-      withPrefix = do
+      withSuffix = do
         rendered >>= (\r -> pure r <> stringChunk (prefMultiSuffix prefs))
-   in (withPrefix, NeverRequired)
+   in (withSuffix, NeverRequired)
 
 -- | Generate a full help text for a parser
 fullDesc :: ParserPrefs -> Parser a -> Chunk Doc

--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -173,7 +173,7 @@ foldTree prefs s (BindNode x) =
 
       -- We always want to display the rendered option
       -- if it exists, and only attach the suffix then.
-      withSuffix = do
+      withSuffix =
         rendered >>= (\r -> pure r <> stringChunk (prefMultiSuffix prefs))
    in (withSuffix, NeverRequired)
 

--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -170,8 +170,11 @@ foldTree prefs s (AltNode b xs) =
 foldTree prefs s (BindNode x) =
   let rendered =
         wrapOver NoDefault NeverRequired (foldTree prefs s x)
-      withPrefix =
-        rendered <> stringChunk (prefMultiSuffix prefs)
+
+      -- We always want to display the rendered option
+      -- if it exists, and only attach the suffix then.
+      withPrefix = do
+        rendered >>= (\r -> pure r <> stringChunk (prefMultiSuffix prefs))
    in (withPrefix, NeverRequired)
 
 -- | Generate a full help text for a parser

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -855,6 +855,13 @@ prop_grouped_many_dual_flag_ellipsis = once $
       r = show . extractChunk $ H.briefDesc p (x *> many x)
   in r === "(-a|-b) [-a|-b]..."
 
+prop_issue_402 :: Property
+prop_issue_402 = once $
+  let x = some (flag' () (short 'a')) <|> some (flag' () (short 'b' <> internal))
+      p = prefs (multiSuffix "...")
+      r = show . extractChunk $ H.briefDesc p x
+  in r === "(-a)..."
+
 prop_nice_some1 :: Property
 prop_nice_some1 = once $
   let x = Options.Applicative.NonEmpty.some1 (flag' () (short 'a'))


### PR DESCRIPTION
Internal and hidden options where picking up a multi suffix which was revealing the bash completion options.

Fixes #402 