### PR TITLE
Guard process package with a flag

### DIFF
--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -60,6 +60,11 @@ source-repository head
   type:     git
   location: https://github.com/pcapriotti/optparse-applicative.git
 
+flag process
+  description:
+    Depend on the process package for Bash autocompletion
+  default: True
+
 library
   hs-source-dirs:      src
   ghc-options:         -Wall
@@ -92,8 +97,10 @@ library
   build-depends:       base                            == 4.*
                      , transformers                    >= 0.2 && < 0.6
                      , transformers-compat             >= 0.3 && < 0.7
-                     , process                         >= 1.0 && < 1.7
                      , ansi-wl-pprint                  >= 0.6.8 && < 0.7
+
+  if flag(process)
+    build-depends:     process                         >= 1.0 && < 1.7
 
   if !impl(ghc >= 8)
     build-depends:     semigroups                      >= 0.10 && < 0.20

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -124,7 +124,6 @@ test-suite tests
                      , Examples.Hello
 
   build-depends:       base
-                     , bytestring                      >= 0.9 && < 0.11
                      , optparse-applicative
                      , QuickCheck                      >= 2.8 && < 2.15
 

--- a/src/Options/Applicative/Builder/Completer.hs
+++ b/src/Options/Applicative/Builder/Completer.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Options.Applicative.Builder.Completer
   ( Completer
   , mkCompleter
@@ -10,7 +12,9 @@ import Control.Applicative
 import Prelude
 import Control.Exception (IOException, try)
 import Data.List (isPrefixOf)
+#ifdef MIN_VERSION_process
 import System.Process (readProcess)
+#endif
 
 import Options.Applicative.Types
 
@@ -31,10 +35,14 @@ listCompleter = listIOCompleter . pure
 -- <http://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html#Programmable-Completion-Builtins>
 -- for a complete list.
 bashCompleter :: String -> Completer
+#ifdef MIN_VERSION_process
 bashCompleter action = Completer $ \word -> do
   let cmd = unwords ["compgen", "-A", action, "--", requote word]
   result <- tryIO $ readProcess "bash" ["-c", cmd] ""
   return . lines . either (const []) id $ result
+#else
+bashCompleter = const $ Completer $ const $ return []
+#endif
 
 tryIO :: IO a -> IO (Either IOException a)
 tryIO = try

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -12,8 +12,6 @@ import qualified Examples.Formatting as Formatting
 
 import           Control.Applicative
 import           Control.Monad
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS8
 import           Data.List hiding (group)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Semigroup hiding (option)
@@ -767,15 +765,6 @@ prop_suggest = once $
     let (msg, _)  = renderFailure failure "prog"
     in  counterexample msg
        $  isInfixOf "Did you mean one of these?\n    first\n    fst" msg
-
-prop_bytestring_reader :: Property
-prop_bytestring_reader = once $
-  let t = "testValue"
-      p :: Parser ByteString
-      p = argument str idm
-      i = info p idm
-      result = run i ["testValue"]
-  in assertResult result $ \xs -> BS8.pack t === xs
 
 prop_grouped_some_option_ellipsis :: Property
 prop_grouped_some_option_ellipsis = once $


### PR DESCRIPTION
I'm trying to employ `optparse-applicative` for an in-package test-suite for `bytestring`. The main difficulty is to avoid circular dependencies, because `bytestring` is pretty ubiquitous. It seems that `process` package is used by `optparse-applicative` only for Bash autocompletion, but incurs a relatively large dependency graph, involving `bytestring` on several occasions.

This PR introduces a cabal flag, allowing to disable `process` when needed. 

Current dependency graph:
![before](https://user-images.githubusercontent.com/2293557/98413671-ec225b80-2071-11eb-8fe3-be55dde0e04b.png)

With `-f-process`:
![after](https://user-images.githubusercontent.com/2293557/98413667-eaf12e80-2071-11eb-8d9f-68d9a02f6b86.png)



