### PR TITLE
Allow completers to disable unwanted shell behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - Make tabulation width configurable in usage texts.
 
+- Add `mkCompleterWithOptions`, allowing completers to
+  request that no space is added after the completion.
+  This is useful in situations where not all completions
+  can be computed efficiently, or when they are too many.
+
 ## Version 0.16.1.0 (21 Nov 2020)
 
 - Guard `process` dependency behind an on by default flag.

--- a/src/Options/Applicative.hs
+++ b/src/Options/Applicative.hs
@@ -212,6 +212,8 @@ module Options.Applicative (
   -- convenience, to use 'bashCompleter' and 'listCompleter' as a 'Mod'.
   Completer,
   mkCompleter,
+  CompletionItem(..),
+  mkCompleterWithOptions,
   listIOCompleter,
 
   listCompleter,

--- a/src/Options/Applicative/BashCompletion.hs
+++ b/src/Options/Applicative/BashCompletion.hs
@@ -167,6 +167,7 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
     render_item :: CompletionItem -> [String]
     render_item CompletionItem { ciOptions = opts, ciValue = val } =
       [ "%addspace" | cioAddSpace opts ]
+      ++ [ "%files" | cioFiles opts ]
       ++ ["%value", val]
 
 bashCompletionScript :: String -> String -> IO [String]
@@ -183,7 +184,7 @@ bashCompletionScript prog progn = return
   , "        CMDLINE=(${CMDLINE[@]} --bash-completion-word $arg)"
   , "    done"
   , ""
-  , "    compopt -o nospace"
+  , "    compopt -o nospace +o filenames"
   , "    COMPREPLY=()"
   , "    for ln in $(" ++ prog ++ " \"${CMDLINE[@]}\"); do"
   , "        if $value_mode; then"
@@ -196,6 +197,9 @@ bashCompletionScript prog progn = return
   , "                    ;;"
   , "                %addspace)"
   , "                    compopt +o nospace"
+  , "                    ;;"
+  , "                %files)"
+  , "                    compopt -o filenames"
   , "                    ;;"
   , "            esac"
   , "        fi"
@@ -301,6 +305,7 @@ zshCompletionScript prog progn = return
   , "    fi"
   , "    value_mode=false"
   , "    addspace=false"
+  , "    files=false"
   , "  else"
   , "    case $word in"
   , "      %value)"
@@ -308,6 +313,9 @@ zshCompletionScript prog progn = return
   , "        ;;"
   , "      %addspace)"
   , "        addspace=true"
+  , "        ;;"
+  , "      %files)"
+  , "        files=true"
   , "        ;;"
   , "    esac"
   , "  fi"

--- a/src/Options/Applicative/BashCompletion.hs
+++ b/src/Options/Applicative/BashCompletion.hs
@@ -67,9 +67,9 @@ bashCompletionParser pinfo pprefs = complParser
 bashCompletionQuery :: ParserInfo a -> ParserPrefs -> Richness -> [String] -> Int -> String -> IO [String]
 bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl pprefs of
   Just (Left (SomeParser p, a))
-    -> list_options a p
+    -> render_items <$> list_options a p
   Just (Right c)
-    -> run_completer c
+    -> render_items <$> run_completer c
   Nothing
     -> return []
   where
@@ -94,12 +94,12 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
     opt_completions argPolicy reachability opt = case optMain opt of
       OptReader ns _ _
          | argPolicy /= AllPositionals
-        -> return . add_opt_help opt $ show_names ns
+        -> return . fmap defaultCompletionItem . add_opt_help opt $ show_names ns
          | otherwise
         -> return []
       FlagReader ns _
          | argPolicy /= AllPositionals
-        -> return . add_opt_help opt $ show_names ns
+        -> return . fmap defaultCompletionItem . add_opt_help opt $ show_names ns
          | otherwise
         -> return []
       ArgReader rdr
@@ -111,7 +111,7 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
          | argumentIsUnreachable reachability
         -> return []
          | otherwise
-        -> return . add_cmd_help p $ filter_names ns
+        -> return . fmap defaultCompletionItem . add_cmd_help p $ filter_names ns
 
     -- When doing enriched completions, add any help specified
     -- to the completion variables (tab separated).
@@ -150,7 +150,7 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
     filter_names :: [String] -> [String]
     filter_names = filter is_completion
 
-    run_completer :: Completer -> IO [String]
+    run_completer :: Completer -> IO [CompletionItem]
     run_completer c = runCompleter c (fromMaybe "" (listToMaybe ws''))
 
     (ws', ws'') = splitAt i ws
@@ -161,11 +161,21 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
         w:_ -> isPrefixOf w
         _ -> const True
 
+    render_items :: [CompletionItem] -> [String]
+    render_items = concatMap render_item
+
+    render_item :: CompletionItem -> [String]
+    render_item CompletionItem { ciOptions = opts, ciValue = val } =
+      [ "%addspace" | cioAddSpace opts ]
+      ++ ["%value", val]
+
 bashCompletionScript :: String -> String -> IO [String]
 bashCompletionScript prog progn = return
+  -- compopt: see complete -o at https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html
   [ "_" ++ progn ++ "()"
   , "{"
   , "    local CMDLINE"
+  , "    local value_mode=false"
   , "    local IFS=$'\\n'"
   , "    CMDLINE=(--bash-completion-index $COMP_CWORD)"
   , ""
@@ -173,7 +183,23 @@ bashCompletionScript prog progn = return
   , "        CMDLINE=(${CMDLINE[@]} --bash-completion-word $arg)"
   , "    done"
   , ""
-  , "    COMPREPLY=( $(" ++ prog ++ " \"${CMDLINE[@]}\") )"
+  , "    compopt -o nospace"
+  , "    COMPREPLY=()"
+  , "    for ln in $(" ++ prog ++ " \"${CMDLINE[@]}\"); do"
+  , "        if $value_mode; then"
+  , "            COMPREPLY+=($ln)"
+  , "            value_mode=false"
+  , "        else"
+  , "            case $ln in"
+  , "                %value)"
+  , "                    value_mode=true"
+  , "                    ;;"
+  , "                %addspace)"
+  , "                    compopt +o nospace"
+  , "                    ;;"
+  , "            esac"
+  , "        fi"
+  , "    done"
   , "}"
   , ""
   , "complete -o filenames -F _" ++ progn ++ " " ++ progn ]
@@ -207,11 +233,23 @@ fishCompletionScript prog progn = return
   , "    for arg in $cl"
   , "      set tmpline $tmpline --bash-completion-word $arg"
   , "    end"
-  , "    for opt in (" ++ prog ++ " $tmpline)"
-  , "      if test -d $opt"
-  , "        echo -E \"$opt/\""
+  , "    set -l value_mode false"
+  , "    for ln in (" ++ prog ++ " $tmpline)"
+  , "      if $value_mode"
+  , "        if test -d $ln"
+  , "          echo -E \"$ln/\""
+  , "        else"
+  , "          echo -E \"$ln\""
+  , "        end"
+  , "        set value_mode false"
   , "      else"
-  , "        echo -E \"$opt\""
+  , "        switch $ln"
+  , "          case '%value'"
+  , "            set value_mode true"
+    --         Ignore %addspace, because fish does not let us remove the end
+    --         space. Dynamic control has not been implemented as of 2020, see
+    --         https://github.com/fish-shell/fish-shell/issues/6928#issuecomment-618012509
+  , "        end"
   , "      end"
   , "    end"
   , "end"
@@ -221,11 +259,15 @@ fishCompletionScript prog progn = return
 
 zshCompletionScript :: String -> String -> IO [String]
 zshCompletionScript prog progn = return
+  -- compadd: http://zsh.sourceforge.net/Doc/Release/Completion-Widgets.html#Completion-Builtin-Commands
   [ "#compdef " ++ progn
   , ""
   , "local request"
   , "local completions"
   , "local word"
+  , "local value_mode=false"
+  , "local addspace=false"
+  , "local files=false"
   , "local index=$((CURRENT - 1))"
   , ""
   , "request=(--bash-completion-enriched --bash-completion-index $index)"
@@ -233,24 +275,41 @@ zshCompletionScript prog progn = return
   , "  request=(${request[@]} --bash-completion-word $arg)"
   , "done"
   , ""
-  , "IFS=$'\\n' completions=($( " ++ prog ++ " \"${request[@]}\" ))"
+  , "IFS=$'\\n' completionLines=($( " ++ prog ++ " \"${request[@]}\" ))"
   , ""
-  , "for word in $completions; do"
-  , "  local -a parts"
+  , "for word in $completionLines; do"
+  , "  if $value_mode; then"
+  , "    local -a parts args"
   , ""
-  , "  # Split the line at a tab if there is one."
-  , "  IFS=$'\\t' parts=($( echo $word ))"
+  , "    # Split the line at a tab if there is one."
+  , "    IFS=$'\\t' parts=($( echo $word ))"
   , ""
-  , "  if [[ -n $parts[2] ]]; then"
-  , "     if [[ $word[1] == \"-\" ]]; then"
-  , "       local desc=(\"$parts[1] ($parts[2])\")"
-  , "       compadd -d desc -- $parts[1]"
-  , "     else"
-  , "       local desc=($(print -f  \"%-019s -- %s\" $parts[1] $parts[2]))"
-  , "       compadd -l -d desc -- $parts[1]"
-  , "     fi"
+  , "    if $addspace; then"
+  , "      args+=( -S' ' )"
+  , "    fi"
+  , ""
+  , "    if [[ -n $parts[2] ]]; then"
+  , "       if [[ $word[1] == \"-\" ]]; then"
+  , "         local desc=(\"$parts[1] ($parts[2])\")"
+  , "         compadd $args -d desc -- $parts[1]"
+  , "       else"
+  , "         local desc=($(print -f  \"%-019s -- %s\" $parts[1] $parts[2]))"
+  , "         compadd $args -l -d desc -- $parts[1]"
+  , "       fi"
+  , "    else"
+  , "      compadd $args -f -- $word"
+  , "    fi"
+  , "    value_mode=false"
+  , "    addspace=false"
   , "  else"
-  , "    compadd -f -- $word"
+  , "    case $word in"
+  , "      %value)"
+  , "        value_mode=true"
+  , "        ;;"
+  , "      %addspace)"
+  , "        addspace=true"
+  , "        ;;"
+  , "    esac"
   , "  fi"
   , "done"
   ]

--- a/src/Options/Applicative/Builder/Completer.hs
+++ b/src/Options/Applicative/Builder/Completer.hs
@@ -20,7 +20,7 @@ import Options.Applicative.Types
 
 -- | Create a 'Completer' from an IO action
 listIOCompleter :: IO [String] -> Completer
-listIOCompleter ss = Completer $ \s ->
+listIOCompleter ss = mkCompleter $ \s ->
   filter (isPrefixOf s) <$> ss
 
 -- | Create a 'Completer' from a constant
@@ -36,7 +36,7 @@ listCompleter = listIOCompleter . pure
 -- for a complete list.
 bashCompleter :: String -> Completer
 #ifdef MIN_VERSION_process
-bashCompleter action = Completer $ \word -> do
+bashCompleter action = mkCompleter $ \word -> do
   let cmd = unwords ["compgen", "-A", action, "--", requote word]
   result <- tryIO $ readProcess "bash" ["-c", cmd] ""
   return . lines . either (const []) id $ result

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -322,15 +322,21 @@ data CompletionItemOptions = CompletionItemOptions {
   --
   -- Set this value to 'False' if the completion is only a prefix of the final
   -- valid values.
-  cioAddSpace :: Bool
+  cioAddSpace :: Bool,
+
+  -- | Whether to treat the completions as file names (if they exists) and
+  -- add a trailing slash to completions that are directories.
+  -- Defaults to 'True'
+  cioFiles :: Bool
 }
 instance Semigroup CompletionItemOptions where
   a <> b =
     CompletionItemOptions {
-      cioAddSpace = cioAddSpace a && cioAddSpace b
+      cioAddSpace = cioAddSpace a && cioAddSpace b,
+      cioFiles = cioFiles a && cioFiles b
     }
 instance Monoid CompletionItemOptions where
-  mempty = CompletionItemOptions True
+  mempty = CompletionItemOptions True True
   mappend = (<>)
 
 -- | A shell complete function.

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -317,6 +317,12 @@ prop_ambiguous = once $
       result = execParserPure (prefs disambiguate) i ["--ba"]
   in  assertError result (\_ -> property succeeded)
 
+completionValues :: [String] -> [String]
+completionValues ("%value" : v : more) = v : completionValues more
+completionValues (('%':_) : more) = completionValues more
+completionValues (a:_) = error ("Unexpected non-% line in completions: " <> a)
+completionValues [] = []
+
 prop_completion :: Property
 prop_completion = once . ioProperty $
   let p = (,)
@@ -327,7 +333,7 @@ prop_completion = once . ioProperty $
   in case result of
     CompletionInvoked (CompletionResult err) -> do
       completions <- lines <$> err "test"
-      return $ ["--foo", "--bar"] === completions
+      return $ ["--foo", "--bar"] === completionValues completions
     Failure _   -> return $ counterexample "unexpected failure" failed
     Success val -> return $ counterexample ("unexpected result " ++ show val) failed
 
@@ -342,7 +348,7 @@ prop_completion_opt_after_double_dash = once . ioProperty $
                     , "--bash-completion-word", "--"]
   in case result of
     CompletionInvoked (CompletionResult err) -> do
-      completions <- lines <$> err "test"
+      completions <- completionValues . lines <$> err "test"
       return $ ["bar"] === completions
     Failure _   -> return $ counterexample "unexpected failure" failed
     Success val -> return $ counterexample ("unexpected result " ++ show val) failed
@@ -357,7 +363,7 @@ prop_completion_only_reachable = once . ioProperty $
       result = run i ["--bash-completion-index", "0"]
   in case result of
     CompletionInvoked (CompletionResult err) -> do
-      completions <- lines <$> err "test"
+      completions <- completionValues . lines <$> err "test"
       return $ ["reachable"] === completions
     Failure _   -> return $ counterexample "unexpected failure" failed
     Success val -> return $ counterexample ("unexpected result " ++ show val) failed
@@ -374,7 +380,7 @@ prop_completion_only_reachable_deep = once . ioProperty $
                      , "--bash-completion-word", "seen" ]
   in case result of
     CompletionInvoked (CompletionResult err) -> do
-      completions <- lines <$> err "test"
+      completions <- completionValues . lines <$> err "test"
       return $ ["now-reachable"] === completions
     Failure _   -> return $ counterexample "unexpected failure" failed
     Success val -> return $ counterexample ("unexpected result " ++ show val) failed
@@ -389,7 +395,7 @@ prop_completion_multi = once . ioProperty $
                      , "--bash-completion-word", "nope" ]
   in case result of
     CompletionInvoked (CompletionResult err) -> do
-      completions <- lines <$> err "test"
+      completions <- completionValues . lines <$> err "test"
       return $ ["reachable"] === completions
     Failure _   -> return $ counterexample "unexpected failure" failed
     Success val -> return $ counterexample ("unexpected result " ++ show val) failed
@@ -403,7 +409,7 @@ prop_completion_rich = once . ioProperty $
       result = run i ["--bash-completion-enriched", "--bash-completion-index", "0"]
   in case result of
     CompletionInvoked (CompletionResult err) -> do
-      completions <- lines <$> err "test"
+      completions <- completionValues . lines <$> err "test"
       return $ ["--foo\tFo?", "--bar\tBa?"] === completions
     Failure _   -> return $ counterexample "unexpected failure" failed
     Success val -> return $ counterexample ("unexpected result " ++ show val) failed
@@ -420,7 +426,7 @@ prop_completion_rich_lengths = once . ioProperty $
                      , "--bash-completion-command-desc-length=30"]
   in case result of
     CompletionInvoked (CompletionResult err) -> do
-      completions <- lines <$> err "test"
+      completions <- completionValues . lines <$> err "test"
       return $ ["--foo\tFoo...", "--bar\tBar..."] === completions
     Failure _   -> return $ counterexample "unexpected failure" failed
     Success val -> return $ counterexample ("unexpected result " ++ show val) failed


### PR DESCRIPTION
This pr adds `mkCompleterWithOptions :: (String -> IO [CompletionItem]) -> Completer`, which allows the completer to disable unwanted shell behaviors like
 - adding a trailing slash to matches that coincide with directories
 - adding a trailing space while the completion is partial

The latter is useful for hierarchical path completions that aren't in the filesystem. Shell come with hacks to make the filesystem case work well, but you need to disable those if you need to implement your own path-like completions.

`zsh` and `bash` have facilities to override this behavior dynamically. `zsh` does so per match, whereas `bash` has parameters we can set per invocation, which seems to work equally well. `fish` doesn't have any of this and decides heuristically based on the last character.

A `CompletionItem` is essentially a tuple of a `String` and `CompletionItemOptions`, where

```haskell
data CompletionItemOptions = CompletionItemOptions {
  -- | Whether to add a space after the completion. Defaults to 'True'.
  --
  -- Set this value to 'False' if the completion is only a prefix of the final
  -- valid values.
  cioAddSpace :: Bool,

  -- | Whether to treat the completions as file names (if they exists) and
  -- add a trailing slash to completions that are directories.
  -- Defaults to 'True'
  cioFiles :: Bool
}
```

The smart constructor `mkCompleter` remains unchanged, which is great for backwards compatibility. The `Types` module does expose the `Completer(Completer)` constructor, but I suppose most packages use the `Options.Applicative` module.

