### PR TITLE
Add biOption for two-argument options

### DIFF
--- a/src/Options/Applicative.hs
+++ b/src/Options/Applicative.hs
@@ -65,6 +65,8 @@ module Options.Applicative (
   strOption,
   option,
 
+  biOption,
+
   strArgument,
   argument,
 
@@ -93,6 +95,7 @@ module Options.Applicative (
   showDefaultWith,
   showDefault,
   metavar,
+  metavar2,
   noArgError,
   hidden,
   internal,
@@ -102,6 +105,7 @@ module Options.Applicative (
   completeWith,
   action,
   completer,
+  completer2,
   idm,
   mappend,
 
@@ -112,8 +116,10 @@ module Options.Applicative (
 
   HasName,
   HasCompleter,
+  HasCompleter2,
   HasValue,
   HasMetavar,
+  HasMetavar2,
   -- ** Readers
   --
   -- | A reader is used by the 'option' and 'argument' builders to parse

--- a/src/Options/Applicative/BashCompletion.hs
+++ b/src/Options/Applicative/BashCompletion.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
 -- | You don't need to import this module to enable bash completion.
 --
 -- See
@@ -91,12 +93,19 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
     --
     -- For options and flags, ensure that the user
     -- hasn't disabled them with `--`.
+    opt_completions :: forall a. ArgPolicy -> ArgumentReachability -> Option a -> IO [String]
     opt_completions argPolicy reachability opt = case optMain opt of
       OptReader ns _ _
          | argPolicy /= AllPositionals
         -> return . add_opt_help opt $ show_names ns
          | otherwise
         -> return []
+      BiOptReader ns _ _ _
+         | argPolicy /= AllPositionals
+        -> return . add_opt_help opt $ show_names ns
+         | otherwise
+        -> return []
+      MapReader _f optr -> opt_completions argPolicy reachability (opt { optMain = optr })
       FlagReader ns _
          | argPolicy /= AllPositionals
         -> return . add_opt_help opt $ show_names ns

--- a/src/Options/Applicative/Builder/Internal.hs
+++ b/src/Options/Applicative/Builder/Internal.hs
@@ -3,8 +3,10 @@ module Options.Applicative.Builder.Internal (
   Mod(..),
   HasName(..),
   HasCompleter(..),
+  HasCompleter2(..),
   HasValue(..),
   HasMetavar(..),
+  HasMetavar2(..),
   OptionFields(..),
   FlagFields(..),
   CommandFields(..),
@@ -35,6 +37,7 @@ import Options.Applicative.Types
 data OptionFields a = OptionFields
   { optNames :: [OptName]
   , optCompleter :: Completer
+  , optCompleter2 :: Completer
   , optNoArgError :: String -> ParseError }
 
 data FlagFields a = FlagFields
@@ -66,6 +69,12 @@ instance HasCompleter OptionFields where
 instance HasCompleter ArgumentFields where
   modCompleter f p = p { argCompleter = f (argCompleter p) }
 
+class HasCompleter2 f where
+  modCompleter2 :: (Completer -> Completer) -> f a -> f a
+
+instance HasCompleter2 OptionFields where
+  modCompleter2 f p = p { optCompleter2 = f (optCompleter2 p) }
+
 class HasValue f where
   -- this is just so that it is not necessary to specify the kind of f
   hasValueDummy :: f a -> ()
@@ -82,6 +91,11 @@ instance HasMetavar ArgumentFields where
   hasMetavarDummy _ = ()
 instance HasMetavar CommandFields where
   hasMetavarDummy _ = ()
+
+class HasMetavar2 f where
+  hasMetavar2Dummy :: f a -> ()
+instance HasMetavar2 OptionFields where
+  hasMetavar2Dummy _ = ()
 
 -- mod --
 
@@ -145,6 +159,7 @@ instance Semigroup (Mod f a) where
 baseProps :: OptProperties
 baseProps = OptProperties
   { propMetaVar = ""
+  , propMetaVar2 = ""
   , propVisibility = Visible
   , propHelp = mempty
   , propShowDefault = Nothing

--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -51,11 +51,14 @@ optDesc pprefs style _reachability opt =
         sort . optionNames . optMain $ opt
       meta =
         stringChunk $ optMetaVar opt
+      meta2 =
+        stringChunk $ optMetaVar2 opt
       descs =
         map (string . showOption) names
       descriptions =
         listToChunk (intersperse (descSep style) descs)
       desc
+        | not (isEmpty meta) && not (isEmpty meta2) = descriptions <<+>> meta <<+>> meta2
         | prefHelpLongEquals pprefs && not (isEmpty meta) && any isLongName (safelast names) =
           descriptions <> stringChunk "=" <> meta
         | otherwise =


### PR DESCRIPTION
This is a potential solution to #271 and #284, observing that both issues only seem to want to parse a fixed number of two arguments per option. That certainly applies to my use case as well.

I don't think this solution is pretty, but it is backwards compatible and it does the job.