### PR TITLE
Add powershell autocompletion script generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,10 +791,10 @@ French commands:
   au-revoir                Say goodbye
 ```
 
-## Bash, Zsh, and Fish Completions
+## Bash, Zsh, Fish, and Pwsh Completions
 
 `optparse-applicative` has built-in support for the completion of
-command line options and arguments in bash, zsh, and fish shells.
+command line options and arguments in bash, zsh, fish, and pwsh shells.
 Any parser, when run using the `execParser` family of functions,
 is automatically extended with a few (hidden) options for the
 completion system:
@@ -817,13 +817,25 @@ completion system:
 
  - `--fish-completion-script`: which is analogous for fish shell;
 
+ - `--pwsh-completion-script`: which is analogous for powershell/pwsh.
+   You might want to generate a script and then dot-source it as
+
+   ```console
+   PS> foo --pwsh-completion-script (Get-Command foo).Source >> _foo.ps1
+   PS> . _foo.ps1
+   ```
+   Note for windows users - this will generate completion script for `foo.exe`,
+   which is not equivalent to `foo` from tab-completion engine's point of view,
+   even though from usage point view they are equivalent. You might want to edit
+   the file `_foo.ps1` if you prefer to use `foo` and not `foo.exe`. 
+
  - `--bash-completion-index`, `--bash-completion-word`: internal options used
    by the completion script to obtain a list of possible completions for a
    given command line;
 
  - `--bash-completion-enriched`: a flag to tell the completion system to emit
    descriptions along with possible completions. This is used to provide help
-   along with the completion for `zsh` and `fish`.
+   along with the completion for `zsh`, `fish`, and `pwsh`.
 
 ### Actions and completers
 

--- a/src/Options/Applicative/BashCompletion.hs
+++ b/src/Options/Applicative/BashCompletion.hs
@@ -62,6 +62,9 @@ bashCompletionParser pinfo pprefs = complParser
       , failure <$>
           (zshCompletionScript <$>
             strOption (long "zsh-completion-script" `mappend` internal))
+      , failure <$>
+          (pwshCompletionScript <$>
+            strOption (long "pwsh-completion-script" `mappend` internal))
       ]
 
 bashCompletionQuery :: ParserInfo a -> ParserPrefs -> Richness -> [String] -> Int -> String -> IO [String]
@@ -253,4 +256,39 @@ zshCompletionScript prog progn = return
   , "    compadd -f -- $word"
   , "  fi"
   , "done"
+  ]
+
+pwshCompletionScript :: String -> String -> IO [String]
+pwshCompletionScript prog progn = return
+  [ "using namespace System.Management.Automation"
+  , "using namespace System.Management.Automation.Language"
+  , "Register-ArgumentCompleter -Native -CommandName '" ++ progn ++ "' -ScriptBlock {"
+  , "    param($wordToComplete, $commandAst)"
+  , "    [string[]]$localCommand = @('\"--bash-completion-enriched\"')"
+  , "    $hay = [System.Collections.Generic.List[string]]::new()"
+  , "    foreach ($item in $commandAst.CommandElements) {"
+  , "        $localCommand += '\"--bash-completion-word\"'"
+  , "        $localCommand += \"\"\"$item\"\"\""
+  , "        $hay.Add($item.ToString())"
+  , "    }"
+  , ""
+  , ""
+  , "    $localCommand += '\"--bash-completion-index\"'"
+  , "    if ($wordToComplete.Equals(\"\")) {"
+  , "        $localCommand += '\"0\"'"
+  , "    }"
+  , "    else {"
+  , "        $localCommand += '\"' + $hay.IndexOf($wordToComplete) + '\"'"
+  , "    }"
+  , "    $inp = & '" ++ prog ++ "' @localCommand"
+  , "    [CompletionResult[]]$out = @()"
+  , "    foreach ($item in $inp) {"
+  , "        $spl = $item.Split(\"`t\")"
+  , "        $show = $spl[0]"
+  , "        $tooltip = if ($spl.Length -eq 1) { $spl[0] } else { $spl[1] }"
+  , "        $crt = if ($show.StartsWith('-')) { [CompletionResultType]::ParameterName } else { [CompletionResultType]::ParameterValue }"
+  , "        $out += [CompletionResult]::new($show, $show.Trim('-'), $crt, $tooltip)"
+  , "    }"
+  , "    $out"
+  , "}"
   ]


### PR DESCRIPTION
This almost completely addresses issue #315. I leverage the same mechanism as other completion scripts. There are some quirks however:

- on a windows machine, due to limitations of [getProgName](https://www.stackage.org/haddock/lts-17.9/base-4.14.1.0/System-Environment.html#v:getProgName) the script will work for `foo.exe`, not `foo`. I mention  this in updated Readme. I will investigate the problem further, maybe it is safe to strip trailling `.exe`.
- powershell-5 has some limitations - it does not trigger autocompletion on `foo --`. This is a known issue, and it will not be fixed. Powershell-7 has no such limitations.

A review of my code and readme wording is most welcome!