### PR TITLE
Fix warnings on recent GHC

### DIFF
--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Options.Applicative.Help.Core (
   cmdDesc,
   briefDesc,
@@ -24,8 +25,12 @@ import Data.Function (on)
 import Data.List (sort, intersperse, groupBy)
 import Data.Foldable (any, foldl')
 import Data.Maybe (maybeToList, catMaybes, fromMaybe)
+#if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (mempty)
+#endif
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup (Semigroup (..))
+#endif
 import Prelude hiding (any)
 
 import Options.Applicative.Common

--- a/src/Options/Applicative/Help/Pretty.hs
+++ b/src/Options/Applicative/Help/Pretty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Options.Applicative.Help.Pretty
   ( module Text.PrettyPrint.ANSI.Leijen
   , (.$.)
@@ -6,7 +7,9 @@ module Options.Applicative.Help.Pretty
   ) where
 
 import           Control.Applicative
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup ((<>))
+#endif
 
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>), columns)
 import           Text.PrettyPrint.ANSI.Leijen.Internal (Doc (..), flatten)


### PR DESCRIPTION
Not sure if it's worth going through the trouble, but it might be nice to have no warnings on all supported GHC versions.