### PR TITLE
Allow options via environment variables #118

### DIFF
--- a/src/Options/Applicative.hs
+++ b/src/Options/Applicative.hs
@@ -89,6 +89,7 @@ module Options.Applicative (
   long,
   help,
   helpDoc,
+  environ,
   value,
   showDefaultWith,
   showDefault,
@@ -171,6 +172,7 @@ module Options.Applicative (
   execParser,
   customExecParser,
   execParserPure,
+  execParserPureEnv,
 
   -- ** Handling parser results manually
   getParseResult,

--- a/src/Options/Applicative/Builder.hs
+++ b/src/Options/Applicative/Builder.hs
@@ -33,6 +33,7 @@ module Options.Applicative.Builder (
   long,
   help,
   helpDoc,
+  environ,
   value,
   showDefaultWith,
   showDefault,
@@ -164,6 +165,13 @@ short = fieldMod . name . OptShort
 -- | Specify a long name for an option.
 long :: HasName f => String -> Mod f a
 long = fieldMod . name . OptLong
+
+-- | Try to read value from environment variable.
+-- If applied many times are tried in order with latter one taking precedence.
+--
+-- /Note/: Same restrictions as for 'value' apply.
+environ :: String -> Mod OptionFields a
+environ var = fieldMod $ \p -> p {optEnvVars = var:optEnvVars p}
 
 -- | Specify a default value for an option.
 --
@@ -367,11 +375,13 @@ strOption = option str
 -- > nameParser = option str ( long "name" <> short 'n' )
 --
 option :: ReadM a -> Mod OptionFields a -> Parser a
-option r m = mkParser d g rdr
+option r m = mkParserEnv envP d g rdr
   where
     Mod f d g = metavar "ARG" `mappend` m
-    fields = f (OptionFields [] mempty ExpectsArgError)
+    fields = f (OptionFields [] [] mempty ExpectsArgError)
     crdr = CReader (optCompleter fields) r
+    envVars = optEnvVars fields
+    envP = if null envVars then Nothing else Just $ EnvP envVars r
     rdr = OptReader (optNames fields) crdr (optNoArgError fields)
 
 -- | Modifier for 'ParserInfo'.

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -30,6 +30,7 @@ module Options.Applicative.Types (
   ArgPolicy(..),
   ArgumentReachability(..),
   AltNodeType(..),
+  Env,
   OptTree(..),
   ParserHelp(..),
   SomeParser(..),
@@ -255,6 +256,7 @@ instance Functor OptReader where
 data Parser a
   = NilP (Maybe a)
   | OptP (Option a)
+  | EnvP [String] (ReadM a)
   | forall x . MultP (Parser (x -> a)) (Parser x)
   | AltP (Parser a) (Parser a)
   | forall x . BindP (Parser x) (x -> Parser a)
@@ -262,6 +264,7 @@ data Parser a
 instance Functor Parser where
   fmap f (NilP x) = NilP (fmap f x)
   fmap f (OptP opt) = OptP (fmap f opt)
+  fmap f (EnvP vars rdr) = EnvP vars (fmap f rdr)
   fmap f (MultP p1 p2) = MultP (fmap (f.) p1) p2
   fmap f (AltP p1 p2) = AltP (fmap f p1) (fmap f p2)
   fmap f (BindP p k) = BindP p (fmap f . k)
@@ -372,6 +375,7 @@ instance Monad ParserResult where
   CompletionInvoked c >>= _ = CompletionInvoked c
 
 type Args = [String]
+type Env = [(String,String)]
 
 -- | Policy for how to handle options within the parse
 data ArgPolicy


### PR DESCRIPTION
Sketched up the solution.

It implies changes to core parser type, but tried to keep changes to API as minimal as possible. Atm it lacks necessary changes to parser docs generation and maybe some other things.

There are also few open questions:

1. Environment vs cmd parsers precedence.
  Widely accepted convention is cmd options taking precedence over environment variables, however, in issue discussion this question was raised. So need to decide whether it should be customizable.
2. IMO it would be nice to replace metavar for `$FOO` when using `environ "FOO"`. In that case we also minimize changes to help text as it becomes self-documenting.
3. Flags and `environ`.
  Smth like `[ -n "${FOO:+x}" ]` is often used and works as a boolean flag "is variable is set and not null". But this is not the only way, so we should make this customizable.
  One of the solutions is to change `environ` type to `ReadM a -> String -> Mod f a`. This will also make possible to use different readers for environment and cmd parser, but I personally don't like this.
  We can also have separate combinators `envOpt :: String -> Mod OptionFields a` and  `envFlag :: String -> ReadM a -> Mod FlagFields a`. Or just add `envReader :: ReadM a -> Mod FlagFields a` and have some default reader for flags.