### PR TITLE
Added support for simple arguments through Generics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ cabal.sandbox.config
 
 .stack-work/
 stack.yaml.lock
+
+.envrc
+.history
+

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import ./nixpkgs.pinned.nix 
+}: let
+  hPkgs = pkgs.haskell.packages.ghc8107;
+in { inherit hPkgs; } // hPkgs.callCabal2nix "optparse-applicative" ../. {}
+

--- a/nix/mkHaskellShell.nix
+++ b/nix/mkHaskellShell.nix
@@ -1,0 +1,18 @@
+{ pkgs ? import ./nixpkgs.pinned.nix
+}: drv: with drv.hPkgs; let
+  name = drv.name;
+  ghc = ghcWithPackages (pkgs: (drv.propagatedBuildInputs ++ drv.buildInputs));
+  watch = pkgs.writeScriptBin "watch" ''
+    ${pkgs.ghcid}/bin/ghcid -c "${cabal-install}/bin/cabal v2-repl $@"
+  '';
+in pkgs.mkShell rec {
+  inherit name;
+  buildInputs = [
+    cabal-install
+    watch
+    haskell-language-server
+  ];
+  HISTFILE = toString ../.history;
+  LOCAL_HISTFILE = HISTFILE;
+}
+

--- a/nix/nixpkgs.pinned.nix
+++ b/nix/nixpkgs.pinned.nix
@@ -1,0 +1,5 @@
+import (builtins.fetchTarball {
+  url    = "https://github.com/NixOS/nixpkgs/archive/9db8c0be81c170d41339ff62f48dc868e4d56d42.tar.gz";
+  sha256 = "139kn3km31wbyzybdrkzfdjw7ynzcbrzcrm3yvp4rpz09f6qfdhc";
+}) {}
+

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -86,6 +86,7 @@ library
                      , Options.Applicative.Builder.Internal
                      , Options.Applicative.Common
                      , Options.Applicative.Extra
+                     , Options.Applicative.Generic
                      , Options.Applicative.Help
                      , Options.Applicative.Help.Chunk
                      , Options.Applicative.Help.Core
@@ -124,6 +125,8 @@ test-suite tests
                      , Examples.Commands
                      , Examples.Formatting
                      , Examples.Hello
+                     , Examples.Generic.Simple
+                     , Examples.Generic.Commands
 
   build-depends:       base
                      , optparse-applicative

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import ./nix/nixpkgs.pinned.nix 
+}: let
+  drv = import ./nix/build.nix { inherit pkgs; };
+in import ./nix/mkHaskellShell.nix { inherit pkgs; } drv
+

--- a/src/Options/Applicative/Generic.hs
+++ b/src/Options/Applicative/Generic.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Options.Applicative.Generic
+    ( simpleOptions
+    , simpleCommands
+    ) where
+
+import GHC.Generics
+import GHC.TypeLits ( KnownSymbol, symbolVal, TypeError, ErrorMessage(..) )
+import Data.Proxy
+import Data.Kind (Type)
+import Data.Typeable
+
+import Options.Applicative.Types
+import Options.Applicative.Builder
+import Data.Char (toUpper)
+
+
+simpleOptions :: (Generic a, GSimpleOptions (Rep a)) => Parser a
+simpleOptions = to <$> gOptionsParserSimple
+
+
+simpleCommands :: (Generic a, GSimpleCommands (Rep a)) => Parser a
+simpleCommands = to <$> toParser (gCommandFields Proxy Proxy)
+
+
+
+class GSimpleOptions a where
+    gOptionsParserSimple :: Parser (a x)
+
+type SimpleOptionsMalformed = 'Text "simpleOptions expects exactly one, nonempty constructor on the data type."
+
+instance TypeError SimpleOptionsMalformed => GSimpleOptions (a :+: b) where
+    gOptionsParserSimple = undefined
+instance TypeError SimpleOptionsMalformed => GSimpleOptions V1 where
+    gOptionsParserSimple = undefined
+instance TypeError SimpleOptionsMalformed => GSimpleOptions U1 where
+    gOptionsParserSimple = undefined
+
+-- Datatype name isn't used
+instance GSimpleOptions a => GSimpleOptions (D1 m a) where
+    gOptionsParserSimple = M1 <$> gOptionsParserSimple
+
+-- Constructor name isn't used in simple case
+instance GSimpleOptions a => GSimpleOptions (C1 m a) where
+    gOptionsParserSimple = M1 <$> gOptionsParserSimple
+
+instance (KnownSymbol n, GIsOption (ToOptUniverse a) a) => GSimpleOptions (S1 ('MetaSel ('Just n) u ss ds) (K1 t a)) where
+    gOptionsParserSimple = M1 . K1 <$> gOption (Proxy :: Proxy (ToOptUniverse a)) n
+      where
+        n = symbolVal (Proxy :: Proxy n)
+instance GIsArg (ToArgUniverse a) a => GSimpleOptions (S1 ('MetaSel 'Nothing u ss ds) (K1 t a)) where
+    gOptionsParserSimple = M1 . K1 <$> gArg (Proxy :: Proxy (ToArgUniverse a))
+
+instance (GSimpleOptions a, GSimpleOptions b) => GSimpleOptions (a :*: b) where
+    gOptionsParserSimple = (:*:) <$> gOptionsParserSimple <*> gOptionsParserSimple
+
+
+newtype Commands a = Commands
+    { getCommands :: [(String, Parser a)]
+    }
+  deriving (Functor, Semigroup)
+
+toParser :: Commands a -> Parser a
+toParser = subparser . foldMap (\(n, p) -> command n (info p mempty)) . getCommands
+
+class GSimpleCommands a where
+    gCommandFields :: proxy0 x -> proxy1 a -> Commands (a x)
+
+-- Datatype name isn't used
+instance GSimpleCommands a => GSimpleCommands (D1 m a) where
+    gCommandFields px _ = M1 <$> gCommandFields px (Proxy :: Proxy a)
+
+-- From constructor we delegate to GSimpleOptions
+instance (KnownSymbol n, GSimpleOptions a) => GSimpleCommands (C1 ('MetaCons n f r) a) where
+    gCommandFields _ _ = Commands [(n, gOptionsParserSimple)]
+      where
+        n = symbolVal (Proxy :: Proxy n)
+
+instance (GSimpleCommands a, GSimpleCommands b) => GSimpleCommands (a :+: b) where
+    gCommandFields px _ = (L1 <$> gCommandFields px (Proxy :: Proxy a)) <> (R1 <$> gCommandFields px (Proxy :: Proxy b))
+
+
+typeName :: forall a f. (HasMetavar f, Typeable a) => Mod f a
+typeName = metavar (map toUpper . show . typeRep $ (Proxy :: Proxy a))
+
+named :: HasName f => String -> Mod f a
+named n = long n <> short (head n)
+
+-- get around overlapping instances
+data OptUniverse = OptBool | OptString | OptOther
+type family ToOptUniverse (a :: Type) :: OptUniverse where
+    ToOptUniverse Bool   = 'OptBool
+    ToOptUniverse String = 'OptString
+    ToOptUniverse a      = 'OptOther
+
+class GIsOption (b :: OptUniverse) a where
+    gOption :: proxy0 b -> String -> Parser a
+
+instance GIsOption 'OptBool Bool where
+    gOption _ n = switch (named n)
+instance GIsOption 'OptString String where
+    gOption _ n = strOption (named n <> metavar "STRING")
+instance (Read a, Typeable a) => GIsOption 'OptOther a where
+    gOption _ n = option auto (named n <> typeName)
+
+-- get around overlapping instances
+data ArgUniverse = ArgString | ArgOther
+type family ToArgUniverse (a :: Type) :: ArgUniverse where
+    ToArgUniverse String = 'ArgString
+    ToArgUniverse a      = 'ArgOther
+
+class GIsArg (b :: ArgUniverse) a where
+    gArg :: proxy0 b -> Parser a
+
+instance GIsArg 'ArgString String where
+    gArg _ = argument str (metavar "STRING")
+instance (Read a, Typeable a) => GIsArg 'ArgOther a where
+    gArg _ = argument auto typeName

--- a/tests/Examples/Generic/Commands.hs
+++ b/tests/Examples/Generic/Commands.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Examples.Generic.Commands where
+
+import GHC.Generics
+import Options.Applicative
+import Options.Applicative.Generic
+
+
+data Sample
+    = Cat String
+    | Copy
+        { file :: String
+        , target :: String          
+        }
+  deriving (Show, Generic)
+
+opts :: ParserInfo Sample
+opts = info (simpleCommands <**> helper)
+  ( fullDesc
+  <> progDesc "Do multiple things"
+  <> header "generic_commands - a test for optparse-applicative" )

--- a/tests/Examples/Generic/Simple.hs
+++ b/tests/Examples/Generic/Simple.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Examples.Generic.Simple where
+
+import GHC.Generics
+import Options.Applicative
+import Options.Applicative.Generic
+
+
+data Sample = Sample
+  { hello  :: String
+  , quiet  :: Bool
+  , repeat :: Int }
+  deriving (Show, Generic)
+
+opts :: ParserInfo Sample
+opts = info (simpleOptions <**> helper)
+  ( fullDesc
+  <> progDesc "Print a greeting"
+  <> header "generic_simple - a test for optparse-applicative" )

--- a/tests/generic_commands.err.txt
+++ b/tests/generic_commands.err.txt
@@ -1,0 +1,12 @@
+generic_commands - a test for optparse-applicative
+
+Usage: generic_commands COMMAND
+
+  Do multiple things
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  Cat                      
+  Copy                     

--- a/tests/generic_simple.err.txt
+++ b/tests/generic_simple.err.txt
@@ -1,0 +1,8 @@
+generic_simple - a test for optparse-applicative
+
+Usage: generic_simple (-h|--hello STRING) [-q|--quiet] (-r|--repeat INT)
+
+  Print a greeting
+
+Available options:
+  -h,--help                Show this help text

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -9,6 +9,8 @@ import qualified Examples.Commands as Commands
 import qualified Examples.Cabal as Cabal
 import qualified Examples.Alternatives as Alternatives
 import qualified Examples.Formatting as Formatting
+import qualified Examples.Generic.Simple as GenericSimple
+import qualified Examples.Generic.Commands as GenericCommands
 
 import           Control.Applicative
 import           Control.Monad
@@ -71,6 +73,16 @@ checkHelpText = checkHelpTextWith ExitSuccess defaultPrefs
 prop_hello :: Property
 prop_hello = once $
   checkHelpText "hello" Hello.opts ["--help"]
+
+prop_generic_simple :: Property
+prop_generic_simple = once $
+  checkHelpText "generic_simple" GenericSimple.opts ["--help"]
+
+
+prop_generic_commands :: Property
+prop_generic_commands = once $
+  checkHelpText "generic_commands" GenericCommands.opts ["--help"]
+
 
 prop_modes :: Property
 prop_modes = once $


### PR DESCRIPTION
This adds `simpleOptions` and `simpleCommands` which create a `Parser` for a type through `GHC.Generics`.

* `simpleOptions` expects the data type to have a single constructor. Each record is interpreted as an option. A `Bool` record results in a `switch`, a `String` in a `strOption` and any other type in a `option auto`. Constructors without records result in series of arguments.
* `simpleCommands` takes a data type with multiple constructors and creates a command for each of them. The constructors themselves are handled the same as for `simpleOptions`

Exampltes can be seen [here](https://github.com/chisui/optparse-applicative/blob/master/tests/Examples/Generic/Simple.hs) and [here](https://github.com/chisui/optparse-applicative/blob/master/tests/Examples/Generic/Commands.hs).

---

This is a proof of concept, so I haven't added haddock or documentation yet. The code also doesn't match the coding style of the rest of the code. If this is something that could be added to aptparse-applicative I will polish the PR.

Theoretically this could be handled by a separate library, but I would rather have this as part of the main lib, since it's just one file. Although I have only tested this with `ghc 8.10.7` and don't know about the compatibility of the type level language extensions used in this PR.