### PR TITLE
runParser: Throws a ParseError that contains the parser

### DIFF
--- a/src/Options/Applicative/Common.hs
+++ b/src/Options/Applicative/Common.hs
@@ -207,7 +207,7 @@ runParser policy isCmdStart p args = case args of
   (arg : argt) -> do
     (mp', args') <- do_step arg argt
     case mp' of
-      Nothing -> hoistMaybe result <|> parseError arg p
+      Nothing -> hoistMaybe result <|> exitP isCmdStart policy p Nothing
       Just p' -> runParser (newPolicy arg) CmdCont p' args'
   where
     result =


### PR DESCRIPTION
when running live completion (e.g., with haskeline), it allows to pinpoint which parser failed autocompletion. As a follow up, one can retreive completions for that specific parser and display those to the user