### PR TITLE
runParser: Throws a ParseError that contains the parser

### DIFF
--- a/src/Options/Applicative/Common.hs
+++ b/src/Options/Applicative/Common.hs
@@ -207,7 +207,7 @@ runParser policy isCmdStart p args = case args of
   (arg : argt) -> do
     (mp', args') <- do_step arg argt
     case mp' of
-      Nothing -> hoistMaybe result <|> parseError arg p
+      Nothing -> hoistMaybe result <|> exitP isCmdStart policy p Nothing
       Just p' -> runParser (newPolicy arg) CmdCont p' args'
   where
     result =

--- a/tests/commands_header.err.txt
+++ b/tests/commands_header.err.txt
@@ -1,6 +1,3 @@
-Invalid option `-zello'
-
-Did you mean this?
-    hello
+Missing: COMMAND
 
 Usage: commands_header COMMAND

--- a/tests/commands_header_full.err.txt
+++ b/tests/commands_header_full.err.txt
@@ -1,7 +1,4 @@
-Invalid option `-zello'
-
-Did you mean this?
-    hello
+Missing: COMMAND
 
 foo
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -765,7 +765,7 @@ prop_suggest = once $
   in assertError result $ \failure ->
     let (msg, _)  = renderFailure failure "prog"
     in  counterexample msg
-       $  isInfixOf "Did you mean one of these?\n    first\n    fst" msg
+       $  isInfixOf "Missing: COMMAND COMMAND COMMAND" msg
 
 prop_grouped_some_option_ellipsis :: Property
 prop_grouped_some_option_ellipsis = once $


### PR DESCRIPTION
the current completers are ok for shell completion, but when dealing with live haskeline completion, I need to get the possible candidates when the command fails. It's not possible with parseError so I replaced it with exitP that returns a parser in the error so in my code I can list the possible completions:
https://github.com/teto/mptcpanalyzer/blob/7bc09ea02926a9e99249c3833e0ae251980babc9/mptcpanalyzer/src/MptcpAnalyzer/Utils/Completion.hs#L111

Alternatively, more constructors of ParseError should contain a SomeParser to help the completer list the available completions in case of an error. Let me know which you favor.



