### PR TITLE
Remove `import Data.Semigroup ((<>))` from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Here's a simple example of a parser.
 
 ```haskell
 import Options.Applicative
-import Data.Semigroup ((<>))
 
 data Sample = Sample
   { hello      :: String


### PR DESCRIPTION
`Data.Semigroup` is exported from Prelude since base-4.11.0.0 (2018).

Changelog entry of exporting `<>` here:
https://hackage.haskell.org/package/base-4.11.0.0/changelog