### PR TITLE
Add --version parser

### DIFF
--- a/src/Options/Applicative.hs
+++ b/src/Options/Applicative.hs
@@ -74,6 +74,7 @@ module Options.Applicative (
   abortOption,
   infoOption,
   helper,
+  simpleVersioner,
 
   -- ** Modifiers
   --

--- a/src/Options/Applicative/Extra.hs
+++ b/src/Options/Applicative/Extra.hs
@@ -6,6 +6,7 @@ module Options.Applicative.Extra (
   helper,
   helperWith,
   hsubparser,
+  simpleVersioner,
   execParser,
   customExecParser,
   execParserPure,
@@ -92,6 +93,19 @@ hsubparser m = mkParser d g rdr
     rdr = CmdReader groupName ((fmap . fmap) add_helper cmds)
     add_helper pinfo = pinfo
       { infoParser = infoParser pinfo <**> helper }
+
+-- | A hidden \"--version\" option that displays the version.
+--
+-- > opts :: ParserInfo Sample
+-- > opts = info (sample <**> simpleVersioner "v1.2.3") mempty
+simpleVersioner :: String -- ^ Version string to be shown
+                -> Parser (a -> a)
+simpleVersioner version = infoOption version $
+  mconcat
+    [ long "version"
+    , help "Show version information"
+    , hidden
+    ]
 
 -- | Run a program description.
 --

--- a/tests/Examples/Cabal.hs
+++ b/tests/Examples/Cabal.hs
@@ -39,10 +39,6 @@ data BuildOpts = BuildOpts
   { buildDir :: FilePath }
   deriving Show
 
-version :: Parser (a -> a)
-version = infoOption "0.0.0"
-  (  long "version"
-  <> help "Print version information" )
 
 parser :: Parser Args
 parser = runA $ proc () -> do
@@ -60,7 +56,7 @@ parser = runA $ proc () -> do
            <> command "build"
               (info buildParser
                     (progDesc "Make this package ready for installation")) ) -< ()
-  A version >>> A helper -< Args opts cmds
+  A (simpleVersioner "0.0.0") >>> A helper -< Args opts cmds
 
 commonOpts :: Parser CommonOpts
 commonOpts = CommonOpts

--- a/tests/cabal.err.txt
+++ b/tests/cabal.err.txt
@@ -9,4 +9,4 @@ Available options:
 
 Global options:
   -v,--verbose LEVEL       Set verbosity to LEVEL
-  --version                Print version information
+  --version                Show version information


### PR DESCRIPTION
This MR contains a new `InfoMod` that allows to specify a version which can be requested with `-v` or `--version`.

Open questions:

- Is `version` a too generic name? Maybe `appVersion` is better?
- Does this need more documentation somewhere?
- Maybe not occupy `-v` as it may be used differently by some apps?