### PR TITLE
Export `helpIndent` from `Options.Applicative`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Export `helpIndent` from `Options.Applicative`.
+
 ## Version 0.17.0.0 (1 Feb 2022)
 
 - Make tabulation width configurable in usage texts.

--- a/src/Options/Applicative.hs
+++ b/src/Options/Applicative.hs
@@ -198,6 +198,7 @@ module Options.Applicative (
   columns,
   helpLongEquals,
   helpShowGlobals,
+  helpIndent,
   defaultPrefs,
 
   -- * Completions


### PR DESCRIPTION
Looks like this was forgotten in #407.