### PR TITLE
Put back example for `optional` in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,14 @@ Having `Applicative` and `Alternative` instances, optparse-applicative
 parsers are also able to be composed with standard combinators. For
 example: `optional :: Alternative f => f a -> f (Maybe a)` will
 mean the user is not required to provide input for the affected
-`Parser`.
+`Parser`. The following option will return `Nothing` instead of failing
+when it's not supplied:
+
+```haskell
+optional $ strOption
+  ( long "output"
+ <> metavar "DIRECTORY" )
+```
 
 ### Running parsers
 

--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ Having `Applicative` and `Alternative` instances, optparse-applicative
 parsers are also able to be composed with standard combinators. For
 example: `optional :: Alternative f => f a -> f (Maybe a)` will
 mean the user is not required to provide input for the affected
-`Parser`. The following option will return `Nothing` instead of failing
-when it's not supplied:
+`Parser`. For example, the following parser will return `Nothing`
+instead of failing if the user doesn't supply an `output` option:
 
 ```haskell
 optional $ strOption


### PR DESCRIPTION
Give example of usage with `optional`, as introduced by e7cc1568c5a112904d06837a086201de0431f6c8 but then removed by 8de333d2aeb6cf32261ff261db48d613b01c33c2. Its removal has caused a slight inconvenience I think for those not as well-versed in `Control.Applicative` combinators, e.g. [this SO question](https://stackoverflow.com/questions/32422339/how-to-parse-an-optional-flag-as-a-maybe-value).