### PR TITLE
Bump pretty printer and stop relying on its internal modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Widen bounds for `ansi-wl-pprint`. This supports the use of `prettyprinter`
+  in a non-breaking way, as the `ansi-wl-pprint > 1.0` support the newer
+  library.
+
 - Export `helpIndent` from `Options.Applicative`.
 
 - Export completion script generators from `Options.Applicative.BashCompletion`.

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -103,7 +103,7 @@ library
   build-depends:       base                            == 4.*
                      , transformers                    >= 0.2 && < 0.7
                      , transformers-compat             >= 0.3 && < 0.8
-                     , ansi-wl-pprint                  >= 0.6.8 && < 0.7
+                     , ansi-wl-pprint                  >= 0.6.8 && < 1.1
 
   if flag(process)
     build-depends:     process                         >= 1.0 && < 1.7

--- a/src/Options/Applicative/BashCompletion.hs
+++ b/src/Options/Applicative/BashCompletion.hs
@@ -1,10 +1,12 @@
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 -- | You don't need to import this module to enable bash completion.
 --
 -- See
 -- <http://github.com/pcapriotti/optparse-applicative/wiki/Bash-Completion the wiki>
 -- for more information on bash completion.
 module Options.Applicative.BashCompletion
-  ( bashCompletionParser, 
+  ( bashCompletionParser,
+
     bashCompletionScript,
     fishCompletionScript,
     zshCompletionScript,

--- a/src/Options/Applicative/Help/Chunk.hs
+++ b/src/Options/Applicative/Help/Chunk.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 module Options.Applicative.Help.Chunk
   ( Chunk(..)
   , chunked

--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 module Options.Applicative.Help.Core (
   cmdDesc,
   briefDesc,
@@ -24,7 +25,7 @@ import Control.Monad (guard)
 import Data.Function (on)
 import Data.List (sort, intersperse, groupBy)
 import Data.Foldable (any, foldl')
-import Data.Maybe (maybeToList, catMaybes, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe)
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (mempty)
 #endif

--- a/src/Options/Applicative/Help/Pretty.hs
+++ b/src/Options/Applicative/Help/Pretty.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# OPTIONS -Wno-warnings-deprecations #-}
 module Options.Applicative.Help.Pretty
   ( module Text.PrettyPrint.ANSI.Leijen
   , (.$.)
@@ -13,7 +14,6 @@ import           Data.Semigroup ((<>))
 #endif
 
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>), columns)
-import           Text.PrettyPrint.ANSI.Leijen.Internal (Doc (..), flatten)
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 import           Prelude
@@ -38,8 +38,8 @@ ifAtRoot =
 --   start of our nesting level.
 ifElseAtRoot :: (Doc -> Doc) -> (Doc -> Doc) -> Doc -> Doc
 ifElseAtRoot f g doc =
-  Nesting $ \i ->
-    Column $ \j ->
+  nesting $ \i ->
+    column $ \j ->
       if i == j
         then f doc
         else g doc
@@ -52,9 +52,7 @@ ifElseAtRoot f g doc =
 --   group.
 groupOrNestLine :: Doc -> Doc
 groupOrNestLine =
-  Union
-    <$> flatten
-    <*> ifNotAtRoot (line <>) . nest 2
+  group . ifNotAtRoot (linebreak <>) . nest 2
 
 
 -- | Separate items in an alternative with a pipe.
@@ -85,7 +83,7 @@ altSep x y =
 --   the starting column, and it won't be indented more.
 hangAtIfOver :: Int -> Int -> Doc -> Doc
 hangAtIfOver i j d =
-  Column $ \k ->
+  column $ \k ->
     if k <= j then
       align d
     else

--- a/src/Options/Applicative/Help/Pretty.hs
+++ b/src/Options/Applicative/Help/Pretty.hs
@@ -1,22 +1,36 @@
 {-# LANGUAGE CPP #-}
-{-# OPTIONS -Wno-warnings-deprecations #-}
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 module Options.Applicative.Help.Pretty
   ( module Text.PrettyPrint.ANSI.Leijen
+  , Doc
+  , indent
+  , renderPretty
+  , displayS
   , (.$.)
   , groupOrNestLine
   , altSep
   , hangAtIfOver
   ) where
 
-import           Control.Applicative
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup ((<>))
 #endif
 
-import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>), columns)
+import           Text.PrettyPrint.ANSI.Leijen hiding (Doc, (<$>), (<>), columns, indent, renderPretty, displayS)
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 import           Prelude
+
+type Doc = PP.Doc
+
+indent :: Int -> PP.Doc -> PP.Doc
+indent = PP.indent
+
+renderPretty :: Float -> Int -> PP.Doc -> SimpleDoc
+renderPretty = PP.renderPretty
+
+displayS :: SimpleDoc -> ShowS
+displayS = PP.displayS
 
 (.$.) :: Doc -> Doc -> Doc
 (.$.) = (PP.<$>)

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -949,12 +949,11 @@ prop_long_command_line_flow = once $
 ---
 
 deriving instance Arbitrary a => Arbitrary (Chunk a)
-deriving instance Eq SimpleDoc
-deriving instance Show SimpleDoc
+
 
 equalDocs :: Float -> Int -> Doc -> Doc -> Property
-equalDocs f w d1 d2 = Doc.renderPretty f w d1
-                  === Doc.renderPretty f w d2
+equalDocs f w d1 d2 = Doc.displayS (Doc.renderPretty f w d1) ""
+                  === Doc.displayS (Doc.renderPretty f w d2) ""
 
 prop_listToChunk_1 :: [String] -> Property
 prop_listToChunk_1 xs = isEmpty (listToChunk xs) === null xs


### PR DESCRIPTION
A recent release of ansi-wl-pprint just changed it to reexport prettyprinter's compat module. By supporting this bump, it unblocks migration of downstream packages.

This means that the prettyprinter library can now be used instead of the ansi-wl-pprint library depending on the version bounds. This was a bit tricky to get right, as there were a few tricks we pulled using the internal modules. Figured it out though.

I've turned off deprection warnings on the module, which is a bit savage, as otherwise it emits many, many, warnings.

This is a half way step, but an acceptable one in my opinion.