### PR TITLE
Add Option groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.19.0.0
+
+- Add `parserOptionGroup` for grouping Options together, similar to command
+  groups. Requires the breaking change of adding the `propGroup :: OptGroup`
+  field to `OptProperties`.
+
 ## Version 0.18.1.0 (29 May 2023)
 
 - Change pretty printer layout algorithm used.

--- a/README.md
+++ b/README.md
@@ -748,6 +748,48 @@ main = customExecParser p opts
     p = prefs showHelpOnEmpty
 ```
 
+#### Option groups
+
+The `parserOptionGroup` function can be used to group options together under
+a common heading. For example, if we have:
+
+```haskell
+Args
+  <$> parseMain
+  <*> parserOptionGroup "Group A" parseA
+  <*> parserOptionGroup "Group B" parseB
+  <*> parseOther
+```
+
+Then the `--help` page `Available options` will look like:
+
+```
+Available options:
+  <main options>
+
+Group A:
+  <A options>
+
+Group B:
+  <B options>
+
+Available options:
+  <other options>
+```
+
+Caveats:
+
+- Parser groups are like command groups in that groups are listed in creation
+  order, and (non-consecutive) duplicate groups are allowed.
+
+- Nested groups are concatenated:
+
+    ```haskell
+    parserOptionGroup "Group A" (parserOptionGroup "Group Z" parseA)
+    ```
+
+    Will group `parseA` under `GroupA.Group Z`.
+
 ### Command groups
 
 One experimental feature which may be useful for programs with many

--- a/README.md
+++ b/README.md
@@ -766,29 +766,33 @@ Then the `--help` page `Available options` will look like:
 ```
 Available options:
   <main options>
+  <other options>
 
-Group A:
+Group A
   <A options>
 
-Group B:
+Group B
   <B options>
-
-Available options:
-  <other options>
 ```
 
 Caveats:
 
 - Parser groups are like command groups in that groups are listed in creation
-  order, and (non-consecutive) duplicate groups are allowed.
+  order, and duplicate groups are consolidated.
 
-- Nested groups are concatenated:
+- Nested groups are indented:
 
     ```haskell
-    parserOptionGroup "Group A" (parserOptionGroup "Group Z" parseA)
+    parserOptionGroup "Group Outer" (parserOptionGroup "Group Inner" parseA)
     ```
 
-    Will group `parseA` under `GroupA.Group Z`.
+    Will render as:
+
+    ```
+    Group Outer
+    - Group Inner
+      ...
+    ```
 
 ### Command groups
 

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -42,6 +42,7 @@ extra-source-files:  CHANGELOG.md
                      tests/parser_group_all_grouped.err.txt
                      tests/parser_group_basic.err.txt
                      tests/parser_group_command_groups.err.txt
+                     tests/parser_group_duplicate_command_groups.err.txt
                      tests/parser_group_duplicates.err.txt
                      tests/parser_group_nested.err.txt
                      tests/nested_optional.err.txt

--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -39,6 +39,11 @@ extra-source-files:  CHANGELOG.md
                      tests/formatting-long-subcommand.err.txt
                      tests/nested.err.txt
                      tests/optional.err.txt
+                     tests/parser_group_all_grouped.err.txt
+                     tests/parser_group_basic.err.txt
+                     tests/parser_group_command_groups.err.txt
+                     tests/parser_group_duplicates.err.txt
+                     tests/parser_group_nested.err.txt
                      tests/nested_optional.err.txt
                      tests/subparsers.err.txt
 
@@ -131,6 +136,12 @@ test-suite tests
                      , Examples.Formatting
                      , Examples.Hello
                      , Examples.LongSub
+                     , Examples.ParserGroup.AllGrouped
+                     , Examples.ParserGroup.Basic
+                     , Examples.ParserGroup.CommandGroups
+                     , Examples.ParserGroup.DuplicateCommandGroups
+                     , Examples.ParserGroup.Duplicates
+                     , Examples.ParserGroup.Nested
 
   build-depends:       base
                      , optparse-applicative

--- a/src/Options/Applicative.hs
+++ b/src/Options/Applicative.hs
@@ -105,6 +105,7 @@ module Options.Applicative (
   completer,
   idm,
   mappend,
+  parserOptionGroup,
 
   OptionFields,
   FlagFields,

--- a/src/Options/Applicative/Builder.hs
+++ b/src/Options/Applicative/Builder.hs
@@ -381,18 +381,23 @@ option r m = mkParser d g rdr
     crdr = CReader (optCompleter fields) r
     rdr = OptReader (optNames fields) crdr (optNoArgError fields)
 
--- | Prepends a group to 'OptProperties'. Nested groups are concatenated
--- together e.g.
+-- | Prepends a group to 'OptProperties'. Nested groups are indented e.g.
 --
 -- @
 --   optPropertiesGroup "Group Outer" (optPropertiesGroup "Group Inner" o)
 -- @
 --
--- will render as "Group Outer.Group Inner".
+-- will render as:
+--
+-- @
+--  Group Outer
+--   - Group Inner
+--     ...
+-- @
 optPropertiesGroup :: String -> OptProperties -> OptProperties
-optPropertiesGroup g o = o { propGroup = updateGroupName g oldGroup }
+optPropertiesGroup g o = o { propGroup = OptGroup (g : oldGroup) }
   where
-    oldGroup = propGroup o
+    OptGroup oldGroup = propGroup o
 
 -- | Prepends a group per 'optPropertiesGroup'.
 optionGroup :: String -> Option a -> Option a
@@ -416,10 +421,10 @@ optionGroup grp o = o { optProps = props' }
 -- >   <main options>
 -- >   <other options>
 -- >
--- > Group A:
+-- > Group A
 -- >   <A options>
 -- >
--- > Group B:
+-- > Group B
 -- >   <B options>
 --
 -- @since 0.19.0.0

--- a/src/Options/Applicative/Builder.hs
+++ b/src/Options/Applicative/Builder.hs
@@ -390,9 +390,9 @@ option r m = mkParser d g rdr
 --
 -- will render as "Group Outer.Group Inner".
 optPropertiesGroup :: String -> OptProperties -> OptProperties
-optPropertiesGroup g o = o { propGroup = OptGroup (g : gs) }
+optPropertiesGroup g o = o { propGroup = updateGroupName g oldGroup }
   where
-    OptGroup gs = propGroup o
+    oldGroup = propGroup o
 
 -- | Prepends a group per 'optPropertiesGroup'.
 optionGroup :: String -> Option a -> Option a

--- a/src/Options/Applicative/Builder.hs
+++ b/src/Options/Applicative/Builder.hs
@@ -400,8 +400,9 @@ optionGroup grp o = o { optProps = props' }
   where
     props' = optPropertiesGroup grp (optProps o)
 
--- | This function can be used to group options together under a common
--- heading. For example, if we have:
+-- | Group options together under a common heading in the help text.
+--
+-- For example, if we have:
 --
 -- > Args
 -- >   <$> parseMain
@@ -413,28 +414,13 @@ optionGroup grp o = o { optProps = props' }
 --
 -- > Available options:
 -- >   <main options>
+-- >   <other options>
 -- >
 -- > Group A:
 -- >   <A options>
 -- >
 -- > Group B:
 -- >   <B options>
--- >
--- > Available options:
--- >   <other options>
---
--- Caveats:
---
---   - Parser groups are like command groups in that groups are listed in
---     creation order, and (non-consecutive) duplicate groups are allowed.
---
---   - Nested groups are concatenated:
---
---       @
---         parserOptionGroup "Group A" (parserOptionGroup "Group Z" parseA)
---       @
---
---       Will group @parseA@ under @"GroupA.Group Z"@.
 --
 -- @since 0.19.0.0
 parserOptionGroup :: String -> Parser a -> Parser a

--- a/src/Options/Applicative/Builder.hs
+++ b/src/Options/Applicative/Builder.hs
@@ -108,8 +108,8 @@ module Options.Applicative.Builder (
   ) where
 
 import Control.Applicative
-#if __GLASGOW_HASKELL__ <= 802
-import Data.Semigroup hiding (option)
+#if __GLASGOW_HASKELL__ < 804
+import Data.Semigroup hiding (Option, option)
 #endif
 import Data.String (fromString, IsString)
 

--- a/src/Options/Applicative/Builder.hs
+++ b/src/Options/Applicative/Builder.hs
@@ -391,8 +391,8 @@ option r m = mkParser d g rdr
 --
 -- @
 --  Group Outer
---   - Group Inner
---     ...
+--  - Group Inner
+--    ...
 -- @
 optPropertiesGroup :: String -> OptProperties -> OptProperties
 optPropertiesGroup g o = o { propGroup = OptGroup (g : oldGroup) }

--- a/src/Options/Applicative/Builder/Internal.hs
+++ b/src/Options/Applicative/Builder/Internal.hs
@@ -151,7 +151,7 @@ baseProps = OptProperties
   , propShowDefault = Nothing
   , propDescMod = Nothing
   , propShowGlobal = True
-  , propGroup = OptGroup 0 Nothing
+  , propGroup = OptGroup []
   }
 
 mkCommand :: Mod CommandFields a -> (Maybe String, [(String, ParserInfo a)])

--- a/src/Options/Applicative/Builder/Internal.hs
+++ b/src/Options/Applicative/Builder/Internal.hs
@@ -151,7 +151,7 @@ baseProps = OptProperties
   , propShowDefault = Nothing
   , propDescMod = Nothing
   , propShowGlobal = True
-  , propGroup = OptGroup []
+  , propGroup = OptGroup 0 Nothing
   }
 
 mkCommand :: Mod CommandFields a -> (Maybe String, [(String, ParserInfo a)])

--- a/src/Options/Applicative/Builder/Internal.hs
+++ b/src/Options/Applicative/Builder/Internal.hs
@@ -151,6 +151,7 @@ baseProps = OptProperties
   , propShowDefault = Nothing
   , propDescMod = Nothing
   , propShowGlobal = True
+  , propGroup = OptGroup []
   }
 
 mkCommand :: Mod CommandFields a -> (Maybe String, [(String, ParserInfo a)])

--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -227,7 +227,7 @@ optionsDesc global pprefs p = vsepChunks
     doc info opt = do
       guard . not . isEmpty $ n
       guard . not . isEmpty $ h
-      return (grp, (extractChunk n, align . extractChunk $ h <<+>> hdef))
+      return (grp, (extractChunk n, align . extractChunk $ h <</>> hdef))
       where
         (grp, n, _) = optDesc pprefs style info opt
         h = optHelp opt

--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -221,7 +221,7 @@ optionsDesc global pprefs p = vsepChunks
             then "Global options:"
             else "Available options:"
 
-        renderGroupStr = (<> pretty ":") . pretty . intercalate "."
+        renderGroupStr = pretty . intercalate "."
 
     doc :: ArgumentReachability -> Option a -> Maybe (OptGroup, (Doc, Doc))
     doc info opt = do

--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -21,10 +21,9 @@ module Options.Applicative.Help.Core (
 
 import Control.Applicative
 import Control.Monad (guard)
-import Data.Function (on)
-import Data.List (sort, intercalate, intersperse, groupBy)
+import Data.List (sort, intercalate, intersperse)
 import Data.Foldable (any, foldl')
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, catMaybes)
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (mempty)
 #endif
@@ -34,7 +33,7 @@ import Data.Semigroup (Semigroup (..))
 import Prelude hiding (any)
 
 import Options.Applicative.Common
-import Options.Applicative.Internal (groupFst)
+import Options.Applicative.Internal (groupFstAll)
 import Options.Applicative.Types
 import Options.Applicative.Help.Pretty
 import Options.Applicative.Help.Chunk
@@ -202,7 +201,7 @@ optionsDesc global pprefs p = vsepChunks
   $ mapParser doc p
   where
     groupByTitle :: [Maybe (OptGroup, (Doc, Doc))] -> [[(OptGroup, (Doc, Doc))]]
-    groupByTitle = groupFst
+    groupByTitle = groupFstAll . catMaybes
 
     tabulateGroup :: [(OptGroup, (Doc, Doc))] -> (OptGroup, Chunk Doc)
     tabulateGroup l@((title,_):_) = (title, tabulate (prefTabulateFill pprefs) (snd <$> l))
@@ -271,7 +270,7 @@ parserHelp pprefs p =
       : (group_title <$> cs)
   where
     def = "Available commands:"
-    cs = groupBy ((==) `on` fst) $ cmdDesc pprefs p
+    cs = groupFstAll $ cmdDesc pprefs p
 
     group_title a@((n, _) : _) =
       with_title (fromMaybe def n) $

--- a/src/Options/Applicative/Internal.hs
+++ b/src/Options/Applicative/Internal.hs
@@ -28,7 +28,7 @@ module Options.Applicative.Internal
   , disamb
 
   , mapParserOptions
-  , groupFst
+  , groupFstAll
   ) where
 
 import Control.Applicative
@@ -41,8 +41,9 @@ import Control.Monad.Trans.Reader
   (mapReaderT, runReader, runReaderT, Reader, ReaderT, ask)
 import Control.Monad.Trans.State (StateT, get, put, modify, evalStateT, runStateT)
 import Data.Function (on)
-import Data.List (groupBy)
-import Data.Maybe (catMaybes)
+import qualified Data.List as L
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NE
 
 import Options.Applicative.Types
 
@@ -275,11 +276,53 @@ hoistList = foldr cons empty
   where
     cons x xs = pure x <|> xs
 
--- | Strips 'Nothing', then groups on the first element of the tuple.
+-- | Groups on the first element of the tuple. This differs from the simple
+-- @groupBy ((==) `on` fst)@ in that non-adjacent groups are __also__ grouped
+-- together. For example:
+--
+-- @
+--   groupFst = groupBy ((==) `on` fst)
+--
+--   let xs = [(1, "a"), (1, "b"), (3, "c"), (2, "d"), (3, "e"), (2, "f")]
+--
+--   groupFst xs === [[(1,"a"),(1,"b")],[(3,"c")],[(2,"d")],[(3,"e")],[(2,"f")]]
+--   groupFstAll xs === [[(1,"a"),(1,"b")],[(3,"c"),(3,"e")],[(2,"d"),(2,"f")]]
+-- @
+--
+-- Notice that the original order is preserved i.e. we do not first sort on
+-- the first element.
 --
 -- @since 0.19.0.0
-groupFst :: (Eq a) => [Maybe (a, b)] -> [[(a, b)]]
-groupFst = groupBy ((==) `on` fst) . catMaybes
+groupFstAll :: Ord a => [(a, b)] -> [[(a, b)]]
+groupFstAll =
+  -- In order to group all (adjacent + non-adjacent) Eq elements together, we
+  -- sort the list so that the Eq elements are in fact adjacent, _then_ group.
+  -- We don't want to destroy the original order, however, so we add a
+  -- temporary index that maintains this original order. The full logic is:
+  --
+  -- 1. Add index i that preserves original order.
+  -- 2. Sort on tuple's fst.
+  -- 3. Group by fst.
+  -- 4. Sort by i, restoring original order.
+  -- 5. Drop index i.
+  fmap (NE.toList . dropIdx)
+    . L.sortOn toIdx
+    . NE.groupBy ((==) `on` fst')
+    . L.sortOn fst'
+    . addIdx
+  where
+    dropIdx :: NonEmpty (Int, (a, b)) -> NonEmpty (a, b)
+    dropIdx = fmap (\(_, y) -> y)
+
+    toIdx :: NonEmpty (Int, (a, b)) -> Int
+    toIdx ((x, _) :| _) = x
+
+    -- Like fst, ignores our added index
+    fst' :: (Int, (a, b)) -> a
+    fst' (_, (x, _)) = x
+
+    addIdx :: [(a, b)] -> [(Int, (a, b))]
+    addIdx = zip [1 ..]
 
 -- | Maps an Option modifying function over the Parser.
 --

--- a/src/Options/Applicative/Internal.hs
+++ b/src/Options/Applicative/Internal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RankNTypes #-}
+
 module Options.Applicative.Internal
   ( P
   , MonadP(..)
@@ -24,6 +26,9 @@ module Options.Applicative.Internal
   , cut
   , (<!>)
   , disamb
+
+  , mapParserOptions
+  , groupFst
   ) where
 
 import Control.Applicative
@@ -35,6 +40,9 @@ import Control.Monad.Trans.Except
 import Control.Monad.Trans.Reader
   (mapReaderT, runReader, runReaderT, Reader, ReaderT, ask)
 import Control.Monad.Trans.State (StateT, get, put, modify, evalStateT, runStateT)
+import Data.Function (on)
+import Data.List (groupBy)
+import Data.Maybe (catMaybes)
 
 import Options.Applicative.Types
 
@@ -266,3 +274,22 @@ hoistList :: Alternative m => [a] -> m a
 hoistList = foldr cons empty
   where
     cons x xs = pure x <|> xs
+
+-- | Strips 'Nothing', then groups on the first element of the tuple.
+--
+-- @since 0.19.0.0
+groupFst :: (Eq a) => [Maybe (a, b)] -> [[(a, b)]]
+groupFst = groupBy ((==) `on` fst) . catMaybes
+
+-- | Maps an Option modifying function over the Parser.
+--
+-- @since 0.19.0.0
+mapParserOptions :: (forall x. Option x -> Option x) -> Parser a -> Parser a
+mapParserOptions f = go
+  where
+    go :: forall y. Parser y -> Parser y
+    go (NilP x) = NilP x
+    go (OptP o) = OptP (f o)
+    go (MultP p1 p2) = MultP (go p1) (go p2)
+    go (AltP p1 p2) = AltP (go p1) (go p2)
+    go (BindP p1 p2) = BindP (go p1) (\x -> go (p2 x))

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -11,6 +11,7 @@ module Options.Applicative.Types (
 
   OptReader(..),
   OptProperties(..),
+  OptGroup(..),
   OptVisibility(..),
   Backtracking(..),
   ReadM(..),
@@ -147,6 +148,18 @@ data OptVisibility
   | Visible           -- ^ visible both in the full and brief descriptions
   deriving (Eq, Ord, Show)
 
+-- | Groups for optionals. Can be multiple in the case of nested groups.
+--
+-- @since 0.19.0.0
+newtype OptGroup = OptGroup [String]
+  deriving (Eq, Show)
+
+instance Semigroup OptGroup where
+  OptGroup xs <> OptGroup ys = OptGroup (xs ++ ys)
+
+instance Monoid OptGroup where
+  mempty = OptGroup []
+
 -- | Specification for an individual parser option.
 data OptProperties = OptProperties
   { propVisibility :: OptVisibility       -- ^ whether this flag is shown in the brief description
@@ -155,17 +168,23 @@ data OptProperties = OptProperties
   , propShowDefault :: Maybe String       -- ^ what to show in the help text as the default
   , propShowGlobal :: Bool                -- ^ whether the option is presented in global options text
   , propDescMod :: Maybe ( Doc -> Doc )   -- ^ a function to run over the brief description
+  , propGroup :: OptGroup
+    -- ^ optional (nested) group
+    --
+    -- @since 0.19.0.0
   }
 
 instance Show OptProperties where
-  showsPrec p (OptProperties pV pH pMV pSD pSG _)
+  showsPrec p (OptProperties pV pH pMV pSD pSG _ pGrp)
     = showParen (p >= 11)
     $ showString "OptProperties { propVisibility = " . shows pV
     . showString ", propHelp = " . shows pH
     . showString ", propMetaVar = " . shows pMV
     . showString ", propShowDefault = " . shows pSD
     . showString ", propShowGlobal = " . shows pSG
-    . showString ", propDescMod = _ }"
+    . showString ", propDescMod = _"
+    . showString ", propGroup = " . shows pGrp
+    . showString "}"
 
 -- | A single option of a parser.
 data Option a = Option

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -159,6 +159,7 @@ instance Semigroup OptGroup where
 
 instance Monoid OptGroup where
   mempty = OptGroup []
+  mappend = (<>)
 
 -- | Specification for an individual parser option.
 data OptProperties = OptProperties

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -152,7 +152,7 @@ data OptVisibility
 --
 -- @since 0.19.0.0
 newtype OptGroup = OptGroup [String]
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 instance Semigroup OptGroup where
   OptGroup xs <> OptGroup ys = OptGroup (xs ++ ys)

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -12,6 +12,7 @@ module Options.Applicative.Types (
   OptReader(..),
   OptProperties(..),
   OptGroup(..),
+  updateGroupName,
   OptVisibility(..),
   Backtracking(..),
   ReadM(..),
@@ -151,15 +152,16 @@ data OptVisibility
 -- | Groups for optionals. Can be multiple in the case of nested groups.
 --
 -- @since 0.19.0.0
-newtype OptGroup = OptGroup [String]
+data OptGroup = OptGroup !Int (Maybe String)
   deriving (Eq, Ord, Show)
 
-instance Semigroup OptGroup where
-  OptGroup xs <> OptGroup ys = OptGroup (xs ++ ys)
-
-instance Monoid OptGroup where
-  mempty = OptGroup []
-  mappend = (<>)
+-- | If the group name is not already set, sets the group name to the
+-- parameter and leaves the index as-is. If, on the other hand, the group
+-- name already exists, we ignore the parameter and increment the index
+-- by one.
+updateGroupName :: String -> OptGroup -> OptGroup
+updateGroupName newName (OptGroup i Nothing) = OptGroup i (Just newName)
+updateGroupName _ (OptGroup i (Just oldName)) = OptGroup (i + 1) (Just oldName)
 
 -- | Specification for an individual parser option.
 data OptProperties = OptProperties

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -12,7 +12,6 @@ module Options.Applicative.Types (
   OptReader(..),
   OptProperties(..),
   OptGroup(..),
-  updateGroupName,
   OptVisibility(..),
   Backtracking(..),
   ReadM(..),
@@ -152,16 +151,8 @@ data OptVisibility
 -- | Groups for optionals. Can be multiple in the case of nested groups.
 --
 -- @since 0.19.0.0
-data OptGroup = OptGroup !Int (Maybe String)
+newtype OptGroup = OptGroup [String]
   deriving (Eq, Ord, Show)
-
--- | If the group name is not already set, sets the group name to the
--- parameter and leaves the index as-is. If, on the other hand, the group
--- name already exists, we ignore the parameter and increment the index
--- by one.
-updateGroupName :: String -> OptGroup -> OptGroup
-updateGroupName newName (OptGroup i Nothing) = OptGroup i (Just newName)
-updateGroupName _ (OptGroup i (Just oldName)) = OptGroup (i + 1) (Just oldName)
 
 -- | Specification for an individual parser option.
 data OptProperties = OptProperties
@@ -172,7 +163,7 @@ data OptProperties = OptProperties
   , propShowGlobal :: Bool                -- ^ whether the option is presented in global options text
   , propDescMod :: Maybe ( Doc -> Doc )   -- ^ a function to run over the brief description
   , propGroup :: OptGroup
-    -- ^ optional (nested) group
+    -- ^ optional group(s)
     --
     -- @since 0.19.0.0
   }

--- a/tests/Examples/ParserGroup/AllGrouped.hs
+++ b/tests/Examples/ParserGroup/AllGrouped.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Examples.ParserGroup.AllGrouped (opts) where
+
+import Options.Applicative
+
+-- Tests the help page when every option belongs to some group i.e. there are
+-- no top-level options. Notice we put the helper (<**> helper) __inside__
+-- one of the groups, so that it is not a top-level option.
+--
+-- Also notice that although we add cmdParser to the same group, it is __not__
+-- rendered as part of this group. This is what we want, as it is an Argument
+-- and should not be rendered with the Options.
+
+data LogGroup = LogGroup
+  { logPath :: Maybe String,
+    logVerbosity :: Maybe Int
+  }
+  deriving (Show)
+
+data SystemGroup = SystemGroup
+  { poll :: Bool,
+    timeout :: Int
+  }
+  deriving (Show)
+
+data Sample = Sample
+  { logGroup :: LogGroup,
+    systemGroup :: SystemGroup,
+    cmd :: String
+  }
+  deriving (Show)
+
+sample :: Parser Sample
+sample = do
+  logGroup <- parseLogGroup
+  systemGroup <- parseSystemGroup
+  cmd <- parseCmd
+
+  pure $
+    Sample
+      { logGroup,
+        systemGroup,
+        cmd
+      }
+  where
+    parseLogGroup =
+      parserOptionGroup "Logging" $
+        LogGroup
+          <$> optional
+            ( strOption
+                ( long "file-log-path"
+                    <> metavar "PATH"
+                    <> help "Log file path"
+                )
+            )
+          <*> optional
+            ( option
+                auto
+                ( long "file-log-verbosity"
+                    <> metavar "INT"
+                    <> help "File log verbosity"
+                )
+            )
+            <**> helper
+
+    parseSystemGroup =
+      parserOptionGroup "System Options" $
+        SystemGroup
+          <$> switch
+            ( long "poll"
+                <> help "Whether to poll"
+            )
+          <*> ( option
+                  auto
+                  ( long "timeout"
+                      <> metavar "INT"
+                      <> help "Whether to time out"
+                  )
+              )
+
+    parseCmd = argument str (metavar "Command")
+
+opts :: ParserInfo Sample
+opts =
+  info
+    sample
+    ( fullDesc
+        <> progDesc "Every option is grouped"
+        <> header "parser_group.all_grouped - a test for optparse-applicative"
+    )

--- a/tests/Examples/ParserGroup/AllGrouped.hs
+++ b/tests/Examples/ParserGroup/AllGrouped.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Examples.ParserGroup.AllGrouped (opts) where
+module Examples.ParserGroup.AllGrouped (opts, main) where
 
 import Data.Semigroup ((<>))
 import Options.Applicative
@@ -34,17 +33,12 @@ data Sample = Sample
   deriving (Show)
 
 sample :: Parser Sample
-sample = do
-  logGroup <- parseLogGroup
-  systemGroup <- parseSystemGroup
-  cmd <- parseCmd
+sample =
+  Sample
+    <$> parseLogGroup
+    <*> parseSystemGroup
+    <*> parseCmd
 
-  pure $
-    Sample
-      { logGroup,
-        systemGroup,
-        cmd
-      }
   where
     parseLogGroup =
       parserOptionGroup "Logging" $
@@ -73,13 +67,12 @@ sample = do
             ( long "poll"
                 <> help "Whether to poll"
             )
-          <*> ( option
-                  auto
-                  ( long "timeout"
-                      <> metavar "INT"
-                      <> help "Whether to time out"
-                  )
-              )
+          <*> option
+                auto
+                ( long "timeout"
+                    <> metavar "INT"
+                    <> help "Whether to time out"
+                )
 
     parseCmd = argument str (metavar "Command")
 
@@ -91,3 +84,8 @@ opts =
         <> progDesc "Every option is grouped"
         <> header "parser_group.all_grouped - a test for optparse-applicative"
     )
+
+main :: IO ()
+main = do
+  r <- customExecParser (prefs helpShowGlobals) opts
+  print r

--- a/tests/Examples/ParserGroup/AllGrouped.hs
+++ b/tests/Examples/ParserGroup/AllGrouped.hs
@@ -3,6 +3,7 @@
 
 module Examples.ParserGroup.AllGrouped (opts) where
 
+import Data.Semigroup ((<>))
 import Options.Applicative
 
 -- Tests the help page when every option belongs to some group i.e. there are

--- a/tests/Examples/ParserGroup/Basic.hs
+++ b/tests/Examples/ParserGroup/Basic.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Examples.ParserGroup.Basic (opts) where
+
+import Options.Applicative
+
+data LogGroup = LogGroup
+  { logPath :: Maybe String,
+    logVerbosity :: Maybe Int
+  }
+  deriving (Show)
+
+data SystemGroup = SystemGroup
+  { poll :: Bool,
+    timeout :: Int
+  }
+  deriving (Show)
+
+data Sample = Sample
+  { hello :: String,
+    logGroup :: LogGroup,
+    quiet :: Bool,
+    systemGroup :: SystemGroup,
+    verbosity :: Int,
+    cmd :: String
+  }
+  deriving (Show)
+
+sample :: Parser Sample
+sample = do
+  hello <- parseHello
+  logGroup <- parseLogGroup
+  quiet <- parseQuiet
+  systemGroup <- parseSystemGroup
+  verbosity <- parseVerbosity
+  cmd <- parseCmd
+
+  pure $
+    Sample
+      { hello,
+        logGroup,
+        quiet,
+        systemGroup,
+        verbosity,
+        cmd
+      }
+  where
+    parseHello =
+      strOption
+        ( long "hello"
+            <> metavar "TARGET"
+            <> help "Target for the greeting"
+        )
+
+    parseLogGroup =
+      parserOptionGroup "Logging" $
+        LogGroup
+          <$> optional
+            ( strOption
+                ( long "file-log-path"
+                    <> metavar "PATH"
+                    <> help "Log file path"
+                )
+            )
+          <*> optional
+            ( option
+                auto
+                ( long "file-log-verbosity"
+                    <> metavar "INT"
+                    <> help "File log verbosity"
+                )
+            )
+
+    parseQuiet =
+      switch
+        ( long "quiet"
+            <> short 'q'
+            <> help "Whether to be quiet"
+        )
+
+    parseSystemGroup =
+      parserOptionGroup "System Options" $
+        SystemGroup
+          <$> switch
+            ( long "poll"
+                <> help "Whether to poll"
+            )
+          <*> ( option
+                  auto
+                  ( long "timeout"
+                      <> metavar "INT"
+                      <> help "Whether to time out"
+                  )
+              )
+
+    parseVerbosity =
+      option
+        auto
+        ( long "verbosity"
+            <> short 'v'
+            <> help "Console verbosity"
+        )
+
+    parseCmd = argument str (metavar "Command")
+
+opts :: ParserInfo Sample
+opts =
+  info
+    (sample <**> helper)
+    ( fullDesc
+        <> progDesc "Shows parser groups"
+        <> header "parser_group.basic - a test for optparse-applicative"
+    )

--- a/tests/Examples/ParserGroup/Basic.hs
+++ b/tests/Examples/ParserGroup/Basic.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Examples.ParserGroup.Basic (opts) where
+module Examples.ParserGroup.Basic (opts, main) where
 
 import Data.Semigroup ((<>))
 import Options.Applicative
@@ -29,23 +28,15 @@ data Sample = Sample
   deriving (Show)
 
 sample :: Parser Sample
-sample = do
-  hello <- parseHello
-  logGroup <- parseLogGroup
-  quiet <- parseQuiet
-  systemGroup <- parseSystemGroup
-  verbosity <- parseVerbosity
-  cmd <- parseCmd
+sample =
+  Sample
+    <$> parseHello
+    <*> parseLogGroup
+    <*> parseQuiet
+    <*> parseSystemGroup
+    <*> parseVerbosity
+    <*> parseCmd
 
-  pure $
-    Sample
-      { hello,
-        logGroup,
-        quiet,
-        systemGroup,
-        verbosity,
-        cmd
-      }
   where
     parseHello =
       strOption
@@ -113,3 +104,8 @@ opts =
         <> progDesc "Shows parser groups"
         <> header "parser_group.basic - a test for optparse-applicative"
     )
+
+main :: IO ()
+main = do
+  r <- customExecParser (prefs helpShowGlobals) opts
+  print r

--- a/tests/Examples/ParserGroup/Basic.hs
+++ b/tests/Examples/ParserGroup/Basic.hs
@@ -3,6 +3,7 @@
 
 module Examples.ParserGroup.Basic (opts) where
 
+import Data.Semigroup ((<>))
 import Options.Applicative
 
 data LogGroup = LogGroup

--- a/tests/Examples/ParserGroup/CommandGroups.hs
+++ b/tests/Examples/ParserGroup/CommandGroups.hs
@@ -1,8 +1,7 @@
-{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Examples.ParserGroup.CommandGroups (opts) where
+module Examples.ParserGroup.CommandGroups (opts, main) where
 
 import Data.Semigroup ((<>))
 import Options.Applicative
@@ -37,23 +36,15 @@ data Sample = Sample
   deriving (Show)
 
 sample :: Parser Sample
-sample = do
-  hello <- parseHello
-  logGroup <- parseLogGroup
-  quiet <- parseQuiet
-  systemGroup <- parseSystemGroup
-  verbosity <- parseVerbosity
-  cmd <- parseCommand
+sample =
+  Sample
+    <$> parseHello
+    <*> parseLogGroup
+    <*> parseQuiet
+    <*> parseSystemGroup
+    <*> parseVerbosity
+    <*> parseCommand
 
-  pure $
-    Sample
-      { hello,
-        logGroup,
-        quiet,
-        systemGroup,
-        verbosity,
-        cmd
-      }
   where
     parseHello =
       strOption
@@ -136,3 +127,8 @@ opts =
         <> progDesc "Option and command groups"
         <> header "parser_group.command_groups - a test for optparse-applicative"
     )
+
+main :: IO ()
+main = do
+  r <- customExecParser (prefs helpShowGlobals) opts
+  print r

--- a/tests/Examples/ParserGroup/CommandGroups.hs
+++ b/tests/Examples/ParserGroup/CommandGroups.hs
@@ -4,6 +4,7 @@
 
 module Examples.ParserGroup.CommandGroups (opts) where
 
+import Data.Semigroup ((<>))
 import Options.Applicative
 
 data LogGroup = LogGroup

--- a/tests/Examples/ParserGroup/CommandGroups.hs
+++ b/tests/Examples/ParserGroup/CommandGroups.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Examples.ParserGroup.CommandGroups (opts) where
+
+import Options.Applicative
+
+data LogGroup = LogGroup
+  { logPath :: Maybe String,
+    logVerbosity :: Maybe Int
+  }
+  deriving (Show)
+
+data SystemGroup = SystemGroup
+  { poll :: Bool,
+    timeout :: Int
+  }
+  deriving (Show)
+
+data Command
+  = Delete
+  | List
+  | Print
+  | Query
+  deriving (Show)
+
+data Sample = Sample
+  { hello :: String,
+    logGroup :: LogGroup,
+    quiet :: Bool,
+    systemGroup :: SystemGroup,
+    verbosity :: Int,
+    cmd :: Command
+  }
+  deriving (Show)
+
+sample :: Parser Sample
+sample = do
+  hello <- parseHello
+  logGroup <- parseLogGroup
+  quiet <- parseQuiet
+  systemGroup <- parseSystemGroup
+  verbosity <- parseVerbosity
+  cmd <- parseCommand
+
+  pure $
+    Sample
+      { hello,
+        logGroup,
+        quiet,
+        systemGroup,
+        verbosity,
+        cmd
+      }
+  where
+    parseHello =
+      strOption
+        ( long "hello"
+            <> metavar "TARGET"
+            <> help "Target for the greeting"
+        )
+
+    parseLogGroup =
+      parserOptionGroup "Logging" $
+        LogGroup
+          <$> optional
+            ( strOption
+                ( long "file-log-path"
+                    <> metavar "PATH"
+                    <> help "Log file path"
+                )
+            )
+          <*> optional
+            ( option
+                auto
+                ( long "file-log-verbosity"
+                    <> metavar "INT"
+                    <> help "File log verbosity"
+                )
+            )
+
+    parseQuiet =
+      switch
+        ( long "quiet"
+            <> short 'q'
+            <> help "Whether to be quiet"
+        )
+
+    parseSystemGroup =
+      parserOptionGroup "System Options" $
+        SystemGroup
+          <$> switch
+            ( long "poll"
+                <> help "Whether to poll"
+            )
+          <*> ( option
+                  auto
+                  ( long "timeout"
+                      <> metavar "INT"
+                      <> help "Whether to time out"
+                  )
+              )
+
+    parseVerbosity =
+      option
+        auto
+        ( long "verbosity"
+            <> short 'v'
+            <> help "Console verbosity"
+        )
+
+    parseCommand =
+      hsubparser
+        ( command "list 2" (info (pure List) $ progDesc "Lists elements")
+        )
+        <|> hsubparser
+        ( command "list" (info (pure List) $ progDesc "Lists elements")
+            <> command "print" (info (pure Print) $ progDesc "Prints table")
+            <> commandGroup "Info commands"
+        )
+        <|> hsubparser
+          ( command "delete" (info (pure Delete) $ progDesc "Deletes elements")
+          )
+        <|> hsubparser
+          ( command "query" (info (pure Query) $ progDesc "Runs a query")
+              <> commandGroup "Query commands"
+          )
+
+opts :: ParserInfo Sample
+opts =
+  info
+    (sample <**> helper)
+    ( fullDesc
+        <> progDesc "Option and command groups"
+        <> header "parser_group.command_groups - a test for optparse-applicative"
+    )

--- a/tests/Examples/ParserGroup/DuplicateCommandGroups.hs
+++ b/tests/Examples/ParserGroup/DuplicateCommandGroups.hs
@@ -4,6 +4,7 @@
 
 module Examples.ParserGroup.DuplicateCommandGroups (opts) where
 
+import Data.Semigroup ((<>))
 import Options.Applicative
 
 -- This test demonstrates that duplicate + consecutive groups are merged,

--- a/tests/Examples/ParserGroup/DuplicateCommandGroups.hs
+++ b/tests/Examples/ParserGroup/DuplicateCommandGroups.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Examples.ParserGroup.DuplicateCommandGroups (opts) where
+
+import Options.Applicative
+
+-- This test demonstrates that duplicate + consecutive groups are merged,
+-- while duplicate + non-consecutive groups are not merged.
+
+data Command
+  = Delete
+  | Insert
+  | List
+  | Print
+  | Query
+  deriving (Show)
+
+data Sample = Sample
+  { hello :: String,
+    quiet :: Bool,
+    verbosity :: Int,
+    cmd :: Command
+  }
+  deriving (Show)
+
+sample :: Parser Sample
+sample = do
+  hello <- parseHello
+  quiet <- parseQuiet
+  verbosity <- parseVerbosity
+  cmd <- parseCommand
+
+  pure $
+    Sample
+      { hello,
+        quiet,
+        verbosity,
+        cmd
+      }
+  where
+    parseHello =
+      strOption
+        ( long "hello"
+            <> metavar "TARGET"
+            <> help "Target for the greeting"
+        )
+
+    parseQuiet =
+      switch
+        ( long "quiet"
+            <> short 'q'
+            <> help "Whether to be quiet"
+        )
+
+    parseVerbosity =
+      option
+        auto
+        ( long "verbosity"
+            <> short 'v'
+            <> help "Console verbosity"
+        )
+
+    parseCommand =
+      hsubparser
+        ( command "list" (info (pure List) $ progDesc "Lists elements")
+            <> commandGroup "Info commands"
+        )
+        <|> hsubparser
+          ( command "delete" (info (pure Delete) $ progDesc "Deletes elements")
+              <> commandGroup "Update commands"
+          )
+        <|> hsubparser
+          ( command "insert" (info (pure Insert) $ progDesc "Inserts elements")
+              <> commandGroup "Update commands"
+          )
+        <|> hsubparser
+          ( command "query" (info (pure Query) $ progDesc "Runs a query")
+          )
+        <|> hsubparser
+        ( command "print" (info (pure Print) $ progDesc "Prints table")
+            <> commandGroup "Info commands"
+        )
+
+opts :: ParserInfo Sample
+opts =
+  info
+    (sample <**> helper)
+    ( fullDesc
+        <> progDesc "Duplicate consecutive command groups consolidated"
+        <> header "parser_group.duplicate_command_groups - a test for optparse-applicative"
+    )

--- a/tests/Examples/ParserGroup/DuplicateCommandGroups.hs
+++ b/tests/Examples/ParserGroup/DuplicateCommandGroups.hs
@@ -1,8 +1,7 @@
-{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Examples.ParserGroup.DuplicateCommandGroups (opts) where
+module Examples.ParserGroup.DuplicateCommandGroups (opts, main) where
 
 import Data.Semigroup ((<>))
 import Options.Applicative
@@ -27,19 +26,13 @@ data Sample = Sample
   deriving (Show)
 
 sample :: Parser Sample
-sample = do
-  hello <- parseHello
-  quiet <- parseQuiet
-  verbosity <- parseVerbosity
-  cmd <- parseCommand
+sample =
+  Sample
+    <$> parseHello
+    <*> parseQuiet
+    <*> parseVerbosity
+    <*> parseCommand
 
-  pure $
-    Sample
-      { hello,
-        quiet,
-        verbosity,
-        cmd
-      }
   where
     parseHello =
       strOption
@@ -92,3 +85,8 @@ opts =
         <> progDesc "Duplicate consecutive command groups consolidated"
         <> header "parser_group.duplicate_command_groups - a test for optparse-applicative"
     )
+
+main :: IO ()
+main = do
+  r <- customExecParser (prefs helpShowGlobals) opts
+  print r

--- a/tests/Examples/ParserGroup/Duplicates.hs
+++ b/tests/Examples/ParserGroup/Duplicates.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Examples.ParserGroup.Duplicates (opts) where
+
+import Options.Applicative
+
+-- NOTE: This is the same structure as ParserGroup.Basic __except__
+-- we have two (non-consecutive) "Logging" groups and two (consecutive)
+-- System groups. This test demonstrates two things:
+--
+-- 1. Non-consecutive groups are not merged (i.e. we display two "Logging"
+--    sections).
+-- 2. Consecutive groups are merged (i.e. we display only one "System" group).
+--
+-- This is like command groups.
+
+data LogGroup1 = LogGroup1
+  { logPath :: Maybe String,
+    logVerbosity :: Maybe Int
+  }
+  deriving (Show)
+
+data LogGroup2 = LogGroup2
+  { logNamespace :: String
+  }
+  deriving (Show)
+
+data SystemGroup1 = SystemGroup1
+  { poll :: Bool,
+    timeout :: Int
+  }
+  deriving (Show)
+
+newtype SystemGroup2 = SystemGroup2
+  { sysFlag :: Bool
+  }
+  deriving (Show)
+
+data Sample = Sample
+  { hello :: String,
+    logGroup1 :: LogGroup1,
+    quiet :: Bool,
+    systemGroup1 :: SystemGroup1,
+    systemGroup2 :: SystemGroup2,
+    logGroup2 :: LogGroup2,
+    verbosity :: Int,
+    cmd :: String
+  }
+  deriving (Show)
+
+sample :: Parser Sample
+sample = do
+  hello <- parseHello
+  logGroup1 <- parseLogGroup1
+  quiet <- parseQuiet
+  systemGroup1 <- parseSystemGroup1
+  systemGroup2 <- parseSystemGroup2
+  logGroup2 <- parseLogGroup2
+  verbosity <- parseVerbosity
+  cmd <- parseCmd
+
+  pure $
+    Sample
+      { hello,
+        logGroup1,
+        quiet,
+        systemGroup1,
+        systemGroup2,
+        logGroup2,
+        verbosity,
+        cmd
+      }
+  where
+    parseHello =
+      strOption
+        ( long "hello"
+            <> metavar "TARGET"
+            <> help "Target for the greeting"
+        )
+
+    parseLogGroup1 =
+      parserOptionGroup "Logging" $
+        LogGroup1
+          <$> optional
+            ( strOption
+                ( long "file-log-path"
+                    <> metavar "PATH"
+                    <> help "Log file path"
+                )
+            )
+          <*> optional
+            ( option
+                auto
+                ( long "file-log-verbosity"
+                    <> metavar "INT"
+                    <> help "File log verbosity"
+                )
+            )
+
+    parseQuiet =
+      switch
+        ( long "quiet"
+            <> short 'q'
+            <> help "Whether to be quiet"
+        )
+
+    parseSystemGroup1 =
+      parserOptionGroup "System" $
+        SystemGroup1
+          <$> switch
+            ( long "poll"
+                <> help "Whether to poll"
+            )
+          <*> ( option
+                  auto
+                  ( long "timeout"
+                      <> metavar "INT"
+                      <> help "Whether to time out"
+                  )
+              )
+
+    parseSystemGroup2 =
+      parserOptionGroup "System" $
+        SystemGroup2
+          <$> switch
+            ( long "sysFlag"
+                <> help "Some flag"
+            )
+
+    parseLogGroup2 =
+      parserOptionGroup "Logging" $
+        LogGroup2
+            <$>
+              ( strOption
+                  ( long "log-namespace"
+                      <> metavar "STR"
+                      <> help "Log namespace"
+                  )
+              )
+
+    parseVerbosity =
+      option
+        auto
+        ( long "verbosity"
+            <> short 'v'
+            <> help "Console verbosity"
+        )
+
+    parseCmd = argument str (metavar "Command")
+
+opts :: ParserInfo Sample
+opts =
+  info
+    (sample <**> helper)
+    ( fullDesc
+        <> progDesc "Duplicate consecutive groups consolidated"
+        <> header "parser_group.duplicates - a test for optparse-applicative"
+    )

--- a/tests/Examples/ParserGroup/Duplicates.hs
+++ b/tests/Examples/ParserGroup/Duplicates.hs
@@ -3,6 +3,7 @@
 
 module Examples.ParserGroup.Duplicates (opts) where
 
+import Data.Semigroup ((<>))
 import Options.Applicative
 
 -- NOTE: This is the same structure as ParserGroup.Basic __except__

--- a/tests/Examples/ParserGroup/Duplicates.hs
+++ b/tests/Examples/ParserGroup/Duplicates.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Examples.ParserGroup.Duplicates (opts) where
+module Examples.ParserGroup.Duplicates (opts, main) where
 
 import Data.Semigroup ((<>))
 import Options.Applicative
@@ -51,27 +50,17 @@ data Sample = Sample
   deriving (Show)
 
 sample :: Parser Sample
-sample = do
-  hello <- parseHello
-  logGroup1 <- parseLogGroup1
-  quiet <- parseQuiet
-  systemGroup1 <- parseSystemGroup1
-  systemGroup2 <- parseSystemGroup2
-  logGroup2 <- parseLogGroup2
-  verbosity <- parseVerbosity
-  cmd <- parseCmd
+sample =
+  Sample
+    <$> parseHello
+    <*> parseLogGroup1
+    <*> parseQuiet
+    <*> parseSystemGroup1
+    <*> parseSystemGroup2
+    <*> parseLogGroup2
+    <*> parseVerbosity
+    <*> parseCmd
 
-  pure $
-    Sample
-      { hello,
-        logGroup1,
-        quiet,
-        systemGroup1,
-        systemGroup2,
-        logGroup2,
-        verbosity,
-        cmd
-      }
   where
     parseHello =
       strOption
@@ -113,13 +102,12 @@ sample = do
             ( long "poll"
                 <> help "Whether to poll"
             )
-          <*> ( option
-                  auto
-                  ( long "timeout"
-                      <> metavar "INT"
-                      <> help "Whether to time out"
-                  )
-              )
+          <*> option
+                auto
+                ( long "timeout"
+                    <> metavar "INT"
+                    <> help "Whether to time out"
+                )
 
     parseSystemGroup2 =
       parserOptionGroup "System" $
@@ -133,12 +121,11 @@ sample = do
       parserOptionGroup "Logging" $
         LogGroup2
             <$>
-              ( strOption
-                  ( long "log-namespace"
-                      <> metavar "STR"
-                      <> help "Log namespace"
-                  )
-              )
+              strOption
+                ( long "log-namespace"
+                    <> metavar "STR"
+                    <> help "Log namespace"
+                )
 
     parseVerbosity =
       option
@@ -158,3 +145,9 @@ opts =
         <> progDesc "Duplicate consecutive groups consolidated"
         <> header "parser_group.duplicates - a test for optparse-applicative"
     )
+
+main :: IO ()
+main = do
+  r <- customExecParser (prefs helpShowGlobals) opts
+  print r
+

--- a/tests/Examples/ParserGroup/Nested.hs
+++ b/tests/Examples/ParserGroup/Nested.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Examples.ParserGroup.Nested (opts) where
+
+import Options.Applicative
+
+-- Nested groups. Demonstrates that group can nest.
+
+data LogGroup = LogGroup
+  { logPath :: Maybe String,
+    systemGroup :: SystemGroup,
+    logVerbosity :: Maybe Int
+  }
+  deriving (Show)
+
+data SystemGroup = SystemGroup
+  { poll :: Bool,
+    timeout :: Int
+  }
+  deriving (Show)
+
+data Sample = Sample
+  { hello :: String,
+    logGroup :: LogGroup,
+    quiet :: Bool,
+    verbosity :: Int,
+    cmd :: String
+  }
+  deriving (Show)
+
+sample :: Parser Sample
+sample = do
+  hello <- parseHello
+  logGroup <- parseLogGroup
+  quiet <- parseQuiet
+  verbosity <- parseVerbosity
+  cmd <- parseCmd
+
+  pure $
+    Sample
+      { hello,
+        logGroup,
+        quiet,
+        verbosity,
+        cmd
+      }
+  where
+    parseHello =
+      strOption
+        ( long "hello"
+            <> metavar "TARGET"
+            <> help "Target for the greeting"
+        )
+
+    parseLogGroup = parserOptionGroup "Logging" $ do
+      logPath <- parseLogPath
+      systemGroup <- parseSystemGroup
+      logVerbosity <- parseLogVerbosity
+      pure $
+        LogGroup
+          { logPath,
+            systemGroup,
+            logVerbosity
+          }
+      where
+        parseLogPath =
+          optional
+            ( strOption
+                ( long "file-log-path"
+                    <> metavar "PATH"
+                    <> help "Log file path"
+                )
+            )
+        parseLogVerbosity =
+          optional
+            ( option
+                auto
+                ( long "file-log-verbosity"
+                    <> metavar "INT"
+                    <> help "File log verbosity"
+                )
+            )
+
+    parseQuiet =
+      switch
+        ( long "quiet"
+            <> short 'q'
+            <> help "Whether to be quiet"
+        )
+
+    parseSystemGroup =
+      parserOptionGroup "System Options" $
+        SystemGroup
+          <$> switch
+            ( long "poll"
+                <> help "Whether to poll"
+            )
+          <*> ( option
+                  auto
+                  ( long "timeout"
+                      <> metavar "INT"
+                      <> help "Whether to time out"
+                  )
+              )
+
+    parseVerbosity =
+      option
+        auto
+        ( long "verbosity"
+            <> short 'v'
+            <> help "Console verbosity"
+        )
+
+    parseCmd = argument str (metavar "Command")
+
+opts :: ParserInfo Sample
+opts =
+  info
+    (sample <**> helper)
+    ( fullDesc
+        <> progDesc "Nested parser groups"
+        <> header "parser_group.nested - a test for optparse-applicative"
+    )

--- a/tests/Examples/ParserGroup/Nested.hs
+++ b/tests/Examples/ParserGroup/Nested.hs
@@ -37,6 +37,7 @@ data Sample = Sample
     logGroup :: LogGroup,
     quiet :: Bool,
     verbosity :: Int,
+    group2 :: (Int, Int),
     cmd :: String
   }
   deriving (Show)
@@ -48,6 +49,7 @@ sample =
     <*> parseLogGroup
     <*> parseQuiet
     <*> parseVerbosity
+    <*> parseGroup2
     <*> parseCmd
 
   where
@@ -58,11 +60,14 @@ sample =
             <> help "Target for the greeting"
         )
 
-    parseLogGroup = parserOptionGroup "Logging" $
-      LogGroup
-        <$> parseLogPath
-        <*> parseSystemGroup
-        <*> parseLogVerbosity
+    parseLogGroup =
+      parserOptionGroup "First group" $
+      parserOptionGroup "Second group" $
+      parserOptionGroup "Logging" $
+        LogGroup
+          <$> parseLogPath
+          <*> parseSystemGroup
+          <*> parseLogVerbosity
 
       where
         parseLogPath =
@@ -106,6 +111,12 @@ sample =
     parseNested3 =
       parserOptionGroup "Nested3" $
         Nested3 <$> option auto (long "triple-nested" <> metavar "STR" <> help "Another option")
+
+    parseGroup2 :: Parser (Int, Int)
+    parseGroup2 = parserOptionGroup "Group 2" $
+      (,)
+        <$> parserOptionGroup "G 2.1" (option auto (long "one" <> help "Option 1"))
+        <*> parserOptionGroup "G 2.2" (option auto (long "two" <> help "Option 2"))
 
     parseVerbosity =
       option auto (long "verbosity" <> short 'v' <> help "Console verbosity")

--- a/tests/Examples/ParserGroup/Nested.hs
+++ b/tests/Examples/ParserGroup/Nested.hs
@@ -3,6 +3,7 @@
 
 module Examples.ParserGroup.Nested (opts) where
 
+import Data.Semigroup ((<>))
 import Options.Applicative
 
 -- Nested groups. Demonstrates that group can nest.

--- a/tests/Examples/ParserGroup/Nested.hs
+++ b/tests/Examples/ParserGroup/Nested.hs
@@ -17,7 +17,19 @@ data LogGroup = LogGroup
 
 data SystemGroup = SystemGroup
   { poll :: Bool,
+    deepNested :: Nested2,
     timeout :: Int
+  }
+  deriving (Show)
+
+data Nested2 = Nested2
+  { nested2Str :: String,
+    nested3 :: Nested3
+  }
+  deriving (Show)
+
+newtype Nested3 = Nested3
+  { nested3Str :: String
   }
   deriving (Show)
 
@@ -97,6 +109,7 @@ sample = do
             ( long "poll"
                 <> help "Whether to poll"
             )
+          <*> parseNested2
           <*> ( option
                   auto
                   ( long "timeout"
@@ -104,6 +117,27 @@ sample = do
                       <> help "Whether to time out"
                   )
               )
+
+    parseNested2 = parserOptionGroup "Nested2" $ do
+      nestedStr2 <-
+        ( option
+            auto
+            ( long "double-nested"
+                <> metavar "STR"
+                <> help "Some nested option"
+            )
+        )
+      nested3 <- parseNested3
+      pure $ Nested2 nestedStr2 nested3
+
+    parseNested3 = parserOptionGroup "Nested3" $
+      ( option
+          (Nested3 <$> auto)
+          ( long "triple-nested"
+              <> metavar "STR"
+              <> help "Another option"
+          )
+      )
 
     parseVerbosity =
       option

--- a/tests/parser_group_all_grouped.err.txt
+++ b/tests/parser_group_all_grouped.err.txt
@@ -1,0 +1,16 @@
+parser_group.all_grouped - a test for optparse-applicative
+
+Usage: parser_group_all_grouped [--file-log-path PATH] 
+                                [--file-log-verbosity INT] [--poll]
+                                --timeout INT Command
+
+  Every option is grouped
+
+Logging:
+  --file-log-path PATH     Log file path
+  --file-log-verbosity INT File log verbosity
+  -h,--help                Show this help text
+
+System Options:
+  --poll                   Whether to poll
+  --timeout INT            Whether to time out

--- a/tests/parser_group_all_grouped.err.txt
+++ b/tests/parser_group_all_grouped.err.txt
@@ -6,11 +6,11 @@ Usage: parser_group_all_grouped [--file-log-path PATH]
 
   Every option is grouped
 
-Logging:
+Logging
   --file-log-path PATH     Log file path
   --file-log-verbosity INT File log verbosity
   -h,--help                Show this help text
 
-System Options:
+System Options
   --poll                   Whether to poll
   --timeout INT            Whether to time out

--- a/tests/parser_group_basic.err.txt
+++ b/tests/parser_group_basic.err.txt
@@ -9,14 +9,14 @@ Usage: parser_group_basic --hello TARGET [--file-log-path PATH]
 Available options:
   --hello TARGET           Target for the greeting
 
-Logging:
+Logging
   --file-log-path PATH     Log file path
   --file-log-verbosity INT File log verbosity
 
 Available options:
   -q,--quiet               Whether to be quiet
 
-System Options:
+System Options
   --poll                   Whether to poll
   --timeout INT            Whether to time out
 

--- a/tests/parser_group_basic.err.txt
+++ b/tests/parser_group_basic.err.txt
@@ -8,18 +8,14 @@ Usage: parser_group_basic --hello TARGET [--file-log-path PATH]
 
 Available options:
   --hello TARGET           Target for the greeting
+  -q,--quiet               Whether to be quiet
+  -v,--verbosity ARG       Console verbosity
+  -h,--help                Show this help text
 
 Logging
   --file-log-path PATH     Log file path
   --file-log-verbosity INT File log verbosity
 
-Available options:
-  -q,--quiet               Whether to be quiet
-
 System Options
   --poll                   Whether to poll
   --timeout INT            Whether to time out
-
-Available options:
-  -v,--verbosity ARG       Console verbosity
-  -h,--help                Show this help text

--- a/tests/parser_group_basic.err.txt
+++ b/tests/parser_group_basic.err.txt
@@ -1,0 +1,25 @@
+parser_group.basic - a test for optparse-applicative
+
+Usage: parser_group_basic --hello TARGET [--file-log-path PATH] 
+                          [--file-log-verbosity INT] [-q|--quiet] [--poll]
+                          --timeout INT (-v|--verbosity ARG) Command
+
+  Shows parser groups
+
+Available options:
+  --hello TARGET           Target for the greeting
+
+Logging:
+  --file-log-path PATH     Log file path
+  --file-log-verbosity INT File log verbosity
+
+Available options:
+  -q,--quiet               Whether to be quiet
+
+System Options:
+  --poll                   Whether to poll
+  --timeout INT            Whether to time out
+
+Available options:
+  -v,--verbosity ARG       Console verbosity
+  -h,--help                Show this help text

--- a/tests/parser_group_command_groups.err.txt
+++ b/tests/parser_group_command_groups.err.txt
@@ -10,14 +10,14 @@ Usage: parser_group_command_groups --hello TARGET [--file-log-path PATH]
 Available options:
   --hello TARGET           Target for the greeting
 
-Logging:
+Logging
   --file-log-path PATH     Log file path
   --file-log-verbosity INT File log verbosity
 
 Available options:
   -q,--quiet               Whether to be quiet
 
-System Options:
+System Options
   --poll                   Whether to poll
   --timeout INT            Whether to time out
 

--- a/tests/parser_group_command_groups.err.txt
+++ b/tests/parser_group_command_groups.err.txt
@@ -9,31 +9,25 @@ Usage: parser_group_command_groups --hello TARGET [--file-log-path PATH]
 
 Available options:
   --hello TARGET           Target for the greeting
+  -q,--quiet               Whether to be quiet
+  -v,--verbosity ARG       Console verbosity
+  -h,--help                Show this help text
 
 Logging
   --file-log-path PATH     Log file path
   --file-log-verbosity INT File log verbosity
 
-Available options:
-  -q,--quiet               Whether to be quiet
-
 System Options
   --poll                   Whether to poll
   --timeout INT            Whether to time out
 
-Available options:
-  -v,--verbosity ARG       Console verbosity
-  -h,--help                Show this help text
-
 Available commands:
   list 2                   Lists elements
+  delete                   Deletes elements
 
 Info commands
   list                     Lists elements
   print                    Prints table
-
-Available commands:
-  delete                   Deletes elements
 
 Query commands
   query                    Runs a query

--- a/tests/parser_group_command_groups.err.txt
+++ b/tests/parser_group_command_groups.err.txt
@@ -1,0 +1,39 @@
+parser_group.command_groups - a test for optparse-applicative
+
+Usage: parser_group_command_groups --hello TARGET [--file-log-path PATH] 
+                                   [--file-log-verbosity INT] [-q|--quiet] 
+                                   [--poll] --timeout INT (-v|--verbosity ARG) 
+                                   (COMMAND | COMMAND | COMMAND | COMMAND)
+
+  Option and command groups
+
+Available options:
+  --hello TARGET           Target for the greeting
+
+Logging:
+  --file-log-path PATH     Log file path
+  --file-log-verbosity INT File log verbosity
+
+Available options:
+  -q,--quiet               Whether to be quiet
+
+System Options:
+  --poll                   Whether to poll
+  --timeout INT            Whether to time out
+
+Available options:
+  -v,--verbosity ARG       Console verbosity
+  -h,--help                Show this help text
+
+Available commands:
+  list 2                   Lists elements
+
+Info commands
+  list                     Lists elements
+  print                    Prints table
+
+Available commands:
+  delete                   Deletes elements
+
+Query commands
+  query                    Runs a query

--- a/tests/parser_group_duplicate_command_groups.err.txt
+++ b/tests/parser_group_duplicate_command_groups.err.txt
@@ -1,0 +1,26 @@
+parser_group.duplicate_command_groups - a test for optparse-applicative
+
+Usage: parser_group_duplicate_command_groups 
+         --hello TARGET [-q|--quiet] (-v|--verbosity ARG) 
+         (COMMAND | COMMAND | COMMAND | COMMAND | COMMAND)
+
+  Duplicate consecutive command groups consolidated
+
+Available options:
+  --hello TARGET           Target for the greeting
+  -q,--quiet               Whether to be quiet
+  -v,--verbosity ARG       Console verbosity
+  -h,--help                Show this help text
+
+Info commands
+  list                     Lists elements
+
+Update commands
+  delete                   Deletes elements
+  insert                   Inserts elements
+
+Available commands:
+  query                    Runs a query
+
+Info commands
+  print                    Prints table

--- a/tests/parser_group_duplicate_command_groups.err.txt
+++ b/tests/parser_group_duplicate_command_groups.err.txt
@@ -12,15 +12,13 @@ Available options:
   -v,--verbosity ARG       Console verbosity
   -h,--help                Show this help text
 
-Info commands
-  list                     Lists elements
-
-Update commands
-  delete                   Deletes elements
-  insert                   Inserts elements
-
 Available commands:
   query                    Runs a query
 
 Info commands
+  list                     Lists elements
   print                    Prints table
+
+Update commands
+  delete                   Deletes elements
+  insert                   Inserts elements

--- a/tests/parser_group_duplicates.err.txt
+++ b/tests/parser_group_duplicates.err.txt
@@ -1,0 +1,30 @@
+parser_group.duplicates - a test for optparse-applicative
+
+Usage: parser_group_duplicates --hello TARGET [--file-log-path PATH] 
+                               [--file-log-verbosity INT] [-q|--quiet] [--poll]
+                               --timeout INT [--sysFlag] --log-namespace STR
+                               (-v|--verbosity ARG) Command
+
+  Duplicate consecutive groups consolidated
+
+Available options:
+  --hello TARGET           Target for the greeting
+
+Logging:
+  --file-log-path PATH     Log file path
+  --file-log-verbosity INT File log verbosity
+
+Available options:
+  -q,--quiet               Whether to be quiet
+
+System:
+  --poll                   Whether to poll
+  --timeout INT            Whether to time out
+  --sysFlag                Some flag
+
+Logging:
+  --log-namespace STR      Log namespace
+
+Available options:
+  -v,--verbosity ARG       Console verbosity
+  -h,--help                Show this help text

--- a/tests/parser_group_duplicates.err.txt
+++ b/tests/parser_group_duplicates.err.txt
@@ -9,22 +9,16 @@ Usage: parser_group_duplicates --hello TARGET [--file-log-path PATH]
 
 Available options:
   --hello TARGET           Target for the greeting
+  -q,--quiet               Whether to be quiet
+  -v,--verbosity ARG       Console verbosity
+  -h,--help                Show this help text
 
 Logging
   --file-log-path PATH     Log file path
   --file-log-verbosity INT File log verbosity
-
-Available options:
-  -q,--quiet               Whether to be quiet
+  --log-namespace STR      Log namespace
 
 System
   --poll                   Whether to poll
   --timeout INT            Whether to time out
   --sysFlag                Some flag
-
-Logging
-  --log-namespace STR      Log namespace
-
-Available options:
-  -v,--verbosity ARG       Console verbosity
-  -h,--help                Show this help text

--- a/tests/parser_group_duplicates.err.txt
+++ b/tests/parser_group_duplicates.err.txt
@@ -10,19 +10,19 @@ Usage: parser_group_duplicates --hello TARGET [--file-log-path PATH]
 Available options:
   --hello TARGET           Target for the greeting
 
-Logging:
+Logging
   --file-log-path PATH     Log file path
   --file-log-verbosity INT File log verbosity
 
 Available options:
   -q,--quiet               Whether to be quiet
 
-System:
+System
   --poll                   Whether to poll
   --timeout INT            Whether to time out
   --sysFlag                Some flag
 
-Logging:
+Logging
   --log-namespace STR      Log namespace
 
 Available options:

--- a/tests/parser_group_nested.err.txt
+++ b/tests/parser_group_nested.err.txt
@@ -1,0 +1,25 @@
+parser_group.nested - a test for optparse-applicative
+
+Usage: parser_group_nested --hello TARGET [--file-log-path PATH] [--poll]
+                           --timeout INT [--file-log-verbosity INT] [-q|--quiet]
+                           (-v|--verbosity ARG) Command
+
+  Nested parser groups
+
+Available options:
+  --hello TARGET           Target for the greeting
+
+Logging:
+  --file-log-path PATH     Log file path
+
+Logging.System Options:
+  --poll                   Whether to poll
+  --timeout INT            Whether to time out
+
+Logging:
+  --file-log-verbosity INT File log verbosity
+
+Available options:
+  -q,--quiet               Whether to be quiet
+  -v,--verbosity ARG       Console verbosity
+  -h,--help                Show this help text

--- a/tests/parser_group_nested.err.txt
+++ b/tests/parser_group_nested.err.txt
@@ -1,21 +1,28 @@
 parser_group.nested - a test for optparse-applicative
 
 Usage: parser_group_nested --hello TARGET [--file-log-path PATH] [--poll]
-                           --timeout INT [--file-log-verbosity INT] [-q|--quiet]
+                           --double-nested STR --triple-nested STR --timeout INT
+                           [--file-log-verbosity INT] [-q|--quiet]
                            (-v|--verbosity ARG) Command
 
   Nested parser groups
 
 Available options:
-  --hello TARGET           Target for the greeting
-  -q,--quiet               Whether to be quiet
-  -v,--verbosity ARG       Console verbosity
-  -h,--help                Show this help text
+  --hello TARGET                 Target for the greeting
+  -q,--quiet                     Whether to be quiet
+  -v,--verbosity ARG             Console verbosity
+  -h,--help                      Show this help text
 
 Logging
-  --file-log-path PATH     Log file path
-  --file-log-verbosity INT File log verbosity
+  --file-log-path PATH           Log file path
+  --file-log-verbosity INT       File log verbosity
 
-Logging.System Options
-  --poll                   Whether to poll
-  --timeout INT            Whether to time out
+- System Options
+    --poll                       Whether to poll
+    --timeout INT                Whether to time out
+
+  - Nested2
+      --double-nested STR        Some nested option
+
+    - Nested3
+        --triple-nested STR      Another option

--- a/tests/parser_group_nested.err.txt
+++ b/tests/parser_group_nested.err.txt
@@ -9,14 +9,14 @@ Usage: parser_group_nested --hello TARGET [--file-log-path PATH] [--poll]
 Available options:
   --hello TARGET           Target for the greeting
 
-Logging:
+Logging
   --file-log-path PATH     Log file path
 
-Logging.System Options:
+Logging.System Options
   --poll                   Whether to poll
   --timeout INT            Whether to time out
 
-Logging:
+Logging
   --file-log-verbosity INT File log verbosity
 
 Available options:

--- a/tests/parser_group_nested.err.txt
+++ b/tests/parser_group_nested.err.txt
@@ -3,26 +3,35 @@ parser_group.nested - a test for optparse-applicative
 Usage: parser_group_nested --hello TARGET [--file-log-path PATH] [--poll]
                            --double-nested STR --triple-nested STR --timeout INT
                            [--file-log-verbosity INT] [-q|--quiet]
-                           (-v|--verbosity ARG) Command
+                           (-v|--verbosity ARG) --one ARG --two ARG Command
 
   Nested parser groups
 
 Available options:
-  --hello TARGET                 Target for the greeting
-  -q,--quiet                     Whether to be quiet
-  -v,--verbosity ARG             Console verbosity
-  -h,--help                      Show this help text
+  --hello TARGET                     Target for the greeting
+  -q,--quiet                         Whether to be quiet
+  -v,--verbosity ARG                 Console verbosity
+  -h,--help                          Show this help text
 
-Logging
-  --file-log-path PATH           Log file path
-  --file-log-verbosity INT       File log verbosity
+First group
+- Second group
+  - Logging
+      --file-log-path PATH           Log file path
+      --file-log-verbosity INT       File log verbosity
 
-- System Options
-    --poll                       Whether to poll
-    --timeout INT                Whether to time out
+    - System Options
+        --poll                       Whether to poll
+        --timeout INT                Whether to time out
 
-  - Nested2
-      --double-nested STR        Some nested option
+      - Nested2
+          --double-nested STR        Some nested option
 
-    - Nested3
-        --triple-nested STR      Another option
+        - Nested3
+            --triple-nested STR      Another option
+
+Group 2
+- G 2.1
+    --one ARG                        Option 1
+
+- G 2.2
+    --two ARG                        Option 2

--- a/tests/parser_group_nested.err.txt
+++ b/tests/parser_group_nested.err.txt
@@ -8,18 +8,14 @@ Usage: parser_group_nested --hello TARGET [--file-log-path PATH] [--poll]
 
 Available options:
   --hello TARGET           Target for the greeting
+  -q,--quiet               Whether to be quiet
+  -v,--verbosity ARG       Console verbosity
+  -h,--help                Show this help text
 
 Logging
   --file-log-path PATH     Log file path
+  --file-log-verbosity INT File log verbosity
 
 Logging.System Options
   --poll                   Whether to poll
   --timeout INT            Whether to time out
-
-Logging
-  --file-log-verbosity INT File log verbosity
-
-Available options:
-  -q,--quiet               Whether to be quiet
-  -v,--verbosity ARG       Console verbosity
-  -h,--help                Show this help text

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -24,7 +24,6 @@ import           Data.List hiding (group)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Semigroup hiding (option)
 import           Data.String
-import           GHC.Stack.Types (HasCallStack)
 
 import           System.Exit
 import           Test.QuickCheck hiding (Success, Failure)
@@ -40,7 +39,6 @@ import           Options.Applicative.Help.Pretty (Doc)
 import qualified Options.Applicative.Help.Pretty as Doc
 import           Options.Applicative.Help.Chunk
 import           Options.Applicative.Help.Levenshtein
-import qualified Options.Applicative.Internal as Internal
 
 import           Prelude
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -10,13 +10,21 @@ import qualified Examples.Cabal as Cabal
 import qualified Examples.Alternatives as Alternatives
 import qualified Examples.Formatting as Formatting
 import qualified Examples.LongSub as LongSub
+import qualified Examples.ParserGroup.AllGrouped as ParserGroup.AllGrouped
+import qualified Examples.ParserGroup.Basic as ParserGroup.Basic
+import qualified Examples.ParserGroup.CommandGroups as ParserGroup.CommandGroups
+import qualified Examples.ParserGroup.DuplicateCommandGroups as ParserGroup.DuplicateCommandGroups
+import qualified Examples.ParserGroup.Duplicates as ParserGroup.Duplicates
+import qualified Examples.ParserGroup.Nested as ParserGroup.Nested
 
 import           Control.Applicative
 import           Control.Monad
+import           Data.Function (on)
 import           Data.List hiding (group)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Semigroup hiding (option)
 import           Data.String
+import           GHC.Stack.Types (HasCallStack)
 
 import           System.Exit
 import           Test.QuickCheck hiding (Success, Failure)
@@ -32,6 +40,7 @@ import           Options.Applicative.Help.Pretty (Doc)
 import qualified Options.Applicative.Help.Pretty as Doc
 import           Options.Applicative.Help.Chunk
 import           Options.Applicative.Help.Levenshtein
+import qualified Options.Applicative.Internal as Internal
 
 import           Prelude
 
@@ -945,6 +954,30 @@ prop_long_command_line_flow = once $
             , "This text should be automatically wrapped "
             , "to fit the size of the terminal" ]) )
   in checkHelpTextWith ExitSuccess (prefs (columns 50)) "formatting-long-subcommand" i ["hello-very-long-sub", "--help"]
+
+prop_parser_group_basic :: Property
+prop_parser_group_basic = once $
+  checkHelpText "parser_group_basic" ParserGroup.Basic.opts ["--help"]
+
+prop_parser_group_command_groups :: Property
+prop_parser_group_command_groups = once $
+  checkHelpText "parser_group_command_groups" ParserGroup.CommandGroups.opts ["--help"]
+
+prop_parser_group_duplicate_command_groups :: Property
+prop_parser_group_duplicate_command_groups = once $
+  checkHelpText "parser_group_duplicate_command_groups" ParserGroup.DuplicateCommandGroups.opts ["--help"]
+
+prop_parser_group_duplicates :: Property
+prop_parser_group_duplicates = once $
+  checkHelpText "parser_group_duplicates" ParserGroup.Duplicates.opts ["--help"]
+
+prop_parser_group_all_grouped :: Property
+prop_parser_group_all_grouped = once $
+  checkHelpText "parser_group_all_grouped" ParserGroup.AllGrouped.opts ["--help"]
+
+prop_parser_group_nested :: Property
+prop_parser_group_nested = once $
+  checkHelpText "parser_group_nested" ParserGroup.Nested.opts ["--help"]
 
 ---
 


### PR DESCRIPTION
Resolves #270.

This is an alternative to #231 by @larskuhtz, for whom I am grateful for blazing the trail.

---

First, thanks for the great library. This is my attempt to resolve #270, as this is a feature I really want (and it seems I am not alone) :slightly_smiling_face:.

Also, this isn't nearly as bad as the diff numbers imply; about 80% of the changes are test boilerplate.

# Background

These are notes on why solving this isn't trivial. Feel free to skip if you're already familiar with the difficulties:

<details>
<summary>Click to expand</summary>

## Commands

Before I jump into the design / impl, I want to first look at why command groups work so well, and why it's harder to do the same for option groups. For commands, the relevant types are:

```haskell
data CommandFields a = CommandFields
  { cmdCommands :: [(String, ParserInfo a)]
  , cmdGroup :: Maybe String }

command :: String -> ParserInfo a -> Mod CommandFields a
commandGroup :: String -> Mod CommandFields a
subparser :: Mod CommandFields a -> Parser a

-- usage
subparser
  ( command "cmd1" ...
      <> command "cmd2" ...
      <> commandGroup "Some group"
  )
```

We can add multiple commands with `command`, add a group with `commandGroup`, and combine all of this together using the `Semigroup` instance. It is easy to add the concept of a group here since the basic modifier -- `CommandFields` -- already collects multiple commands together. So all we have to do is add an optional label and render it appropriately.

## Options

Now let's look at `Option`.

```haskell
-- Option does not show up in the signatures for user-facing functions like
-- 'option', but it is used internally i.e. part of the Parser type.
data Option a = Option
  { optMain :: OptReader a
  , optProps :: OptProperties
  }

data OptionFields a = OptionFields
  { optNames :: [OptName]
  , optCompleter :: Completer
  , optNoArgError :: String -> ParseError }

-- Focusing on 'option', but the same applies to argument and flag since they
-- all go through the Option type.
option :: ReadM a -> Mod OptionFields a -> Parser a
```

Unlike `CommandFields`, `OptionFields` does _not_ take in multiple options, so we cannot easily add an optional group label. Perhaps we can simply make one? Say,

```haskell
data GroupedOptions a = GroupedOptions
  { options :: [Option a]
  , optGroup :: Maybe String
  }
```

Unfortunately, this won't work! The fundamental problem is different options usually have different types -- unlike different commands, which must have the same type -- so we cannot, say, group an `Option Int` and `Option String` together (at least not without existential types, which would probably be terrible).

</details>

# Solutions

As far as I can tell, there are really only two possibilities for a user-facing `groupOption :: String -> ...`.

## 1. Add an optional group to `OptionFields` (and `ArgumentFields`, `FlagFields`)

This is what the previous PR did:

```haskell
class HasGroup f where
  setGroup :: String -> f a -> f a
  getGroup :: f a -> Maybe String

instance HasGroup OptionFields where ...

-- usage
parseFoo =
  optional
      ( strOption
          ( long "file-log-path"
              <> metavar "PATH"
              <> help "Log file path"
              <> setGroup "Some group" -- use OptionFields' HasGroup instance
          )
      )
```

The advantage is that this fits well with standard optparse usage, and it is probably the most obvious way to retrofit option groups into the existing framework.

The disadvantage is that we have to individually add `setGroup "Some group"` to every option we want in `"Some Group"`. It's clunky, and opens up the possibility for typos creating multiple groups. This is also inconsistent with how command groups work, as you only have to specify the group once for the latter. Unfortunately our hand is forced due to options having different types.

I assume this is the primary reason the PR was declined, perhaps along with some concern over the necessary implementation changes.

## 2. Add an optional group to OptProperties

This is what this PR does. Because this is at a "higher level" than `Mod`, our user-facing function is:

```haskell
parserOptionGroup :: String -> Parser a -> Parser a

-- usage
-- every parser that constitutes someParser will be grouped together
parserOptionGroup "Some group" someParser
```

The disadvantage is that isn't the usual `Mod` semigroup pattern.

The advantage is that we only have to specify the group in one place, and all "downstream" parsers will automatically belong to the same group.

The other advantage is that the code changes are quite small. Other than the rendering logic (which is nearly identical to the first PR, thanks @larskuhtz!), the only modification here is adding the new field to `OptProperties`, and providing a set function.

# Examples

The tests show examples of what this looks like. For a "realer" example, I tried this out on a CLI app with many options. [Here](https://github.com/tbidne/shrun/compare/main...optparse-groups#diff-1f60c193359ba067c987a9f6320256a11015a4a9c737ee09a24780b3ac2271afL37) is the diff, and here is the original help page (brace yourself):

<details>
<summary>Click to expand</summary>

```
Shrun: A tool for running shell commands concurrently.

Usage: shrun [-c|--config PATH] [-i|--init STRING] 
             [-t|--timeout (NATURAL | STRING)] [--common-log-key-hide] 
             [--command-log-poll-interval NATURAL] 
             [--command-log-read-size BYTES] [--console-log-command] 
             [--console-log-command-name-trunc NATURAL] 
             [--console-log-line-trunc (NATURAL | detect)] 
             [--console-log-strip-control (all | smart | none)] 
             [--console-log-timer-format (digital_compact | digital_full | prose_compact | prose_full)]
             [-f|--file-log (default | PATH)] 
             [--file-log-command-name-trunc NATURAL] 
             [--file-log-delete-on-success] 
             [--file-log-line-trunc (NATURAL | detect)] 
             [--file-log-mode (append | write)] 
             [--file-log-size-mode (warn BYTES | delete BYTES | nothing)] 
             [--file-log-strip-control (all | smart | none)] 
             [--notify-action (final |command | all)] 
             [--notify-system (dbus | notify-send | apple-script)] 
             [--notify-timeout (never | NATURAL)] [--default-config] 
             [-v|--version] Commands...

  Shrun runs shell commands concurrently. In addition to providing basic timing
  and logging functionality, we also provide the ability to pass in a config
  file that can be used to define aliases for commands.

  In general, each option --foo has a --no-foo variant that disables cli and
  toml configuration for that field. For example, the --no-console-log-command
  option will instruct shrun to ignore both cli --console-log-command and toml
  console-log.command, ensuring the default behavior is used (i.e. no command
  logging).

  See github.com/tbidne/shrun#README for full documentation.

Available options:
  -c,--config PATH         Path to TOML config file. If this argument is not
                           given we automatically look in the XDG config
                           directory e.g. ~/.config/shrun/config.toml. The
                           --no-config option disables --config and the
                           automatic XDG lookup.

  --no-config              Disables --config.

  -i,--init STRING         If given, init is run before each command. That is,
                           'shrun --init ". ~/.bashrc" foo bar' is equivalent to
                           'shrun ". ~/.bashrc && foo" ". ~/.bashrc && bar"'.

  --no-init                Disables --init.

  -t,--timeout (NATURAL | STRING)
                           Non-negative integer setting a timeout. Can either be
                           a raw number (interpreted as seconds), or a "time
                           string" e.g. 1d2h3m4s or 2h3s. Defaults to no
                           timeout.

  --no-timeout             Disables --timeout.

  --common-log-key-hide    By default, we display the key name from the legend
                           over the actual command that was run, if the former
                           exists. This flag instead shows the literal command.
                           Commands without keys are unaffected.

  --no-common-log-key-hide Disables --common-log-key-hide.

  --command-log-poll-interval NATURAL
                           Non-negative integer used in conjunction with
                           --console-log-command and --file-log that determines
                           how quickly we poll commands for logs, in
                           microseconds. A value of 0 is interpreted as infinite
                           i.e. limited only by the CPU. Defaults to 10,000.
                           Note that lower values will increase CPU usage. In
                           particular, 0 will max out a CPU thread.

  --no-command-log-poll-interval
                           Disables --command-log-poll-interval.

  --command-log-read-size BYTES
                           The max number of bytes in a single read when
                           streaming command logs (--console-log-command and
                           --file-log). Logs larger than --command-log-read-size
                           will be read in a subsequent read, hence broken
                           across lines. The default is '1 kb'.

  --no-command-log-read-size
                           Disables --command-log-read-size.

  --console-log-command    The default behavior is to swallow logs for the
                           commands themselves. This flag gives each command a
                           console region in which its logs will be printed.
                           Only the latest log per region is show at a given
                           time.

  --no-console-log-command Disables --console-log-command.

  --console-log-command-name-trunc NATURAL
                           Non-negative integer that limits the length of
                           commands/key-names in the console logs. Defaults to
                           no truncation.

  --no-console-log-command-name-trunc
                           Disables --console-log-command-name-trunc.

  --console-log-line-trunc (NATURAL | detect)
                           Non-negative integer that limits the length of
                           console logs. Can also be the string literal
                           'detect', to detect the terminal size automatically.
                           Defaults to no truncation. Note that "log prefixes"
                           (e.g. labels like [Success], timestamps) are counted
                           towards the total length but are never truncated.

  --no-console-log-line-trunc
                           Disables --console-log-line-trunc.

  --console-log-strip-control (all | smart | none)
                           Control characters can wreak layout havoc, thus we
                           include this option. 'all' strips all such chars.
                           'none' does nothing i.e. all chars are left
                           untouched. The default 'smart' attempts to strip only
                           the control chars that affect layout (e.g. cursor
                           movements) and leaves others unaffected (e.g.
                           colors). This has the potential to be the 'prettiest'
                           though it is possible to miss some chars. This option
                           is experimental and subject to change.

  --no-console-log-strip-control
                           Disables --console-log-strip-control.

  --console-log-timer-format (digital_compact | digital_full | prose_compact | prose_full)
                           How to format the timer. Defaults to prose_compact
                           e.g. '2 hours, 3 seconds'.

  --no-console-log-timer-format
                           Disables --console-log-timer-format.

  -f,--file-log (default | PATH)
                           If a path is supplied, all logs will additionally be
                           written to the supplied file. Furthermore, command
                           logs will be written to the file irrespective of
                           --console-log-command. Console logging is unaffected.
                           This can be useful for investigating command
                           failures. If the string 'default' is given, then we
                           write to the XDG state directory e.g.
                           ~/.local/state/shrun/shrun.log.

  --no-file-log            Disables --file-log.

  --file-log-command-name-trunc NATURAL
                           Like --console-log-command-name-trunc, but for
                           --file-logs.

  --no-file-log-command-name-trunc
                           Disables --file-log-command-name-trunc.

  --file-log-delete-on-success
                           If --file-log is active, deletes the file on a
                           successful exit. Does not delete the file if shrun
                           exited via failure.

  --no-file-log-delete-on-success
                           Disables --file-log-delete-on-success.

  --file-log-line-trunc (NATURAL | detect)
                           Like --console-log-line-trunc, but for --file-log.

  --no-file-log-line-trunc Disables --file-log-line-trunc.

  --file-log-mode (append | write)
                           Mode in which to open the log file. Defaults to
                           write.

  --no-file-log-mode       Disables --file-log-mode.

  --file-log-size-mode (warn BYTES | delete BYTES | nothing)
                           Sets a threshold for the file log size, upon which we
                           either print a warning or delete the file, if it is
                           exceeded. The BYTES should include the value and
                           units e.g. warn 10 mb, warn 5 gigabytes, delete
                           20.5B. Defaults to warning at 50 mb.

  --no-file-log-size-mode  Disables --file-log-size-mode.

  --file-log-strip-control (all | smart | none)
                           --console-log-strip-control for file logs created
                           with --file-log. Defaults to all.

  --no-file-log-strip-control
                           Disables --file-log-strip-control.

  --notify-action (final |command | all)
                           Sends notifications for various actions. 'Final'
                           sends off a notification when Shrun itself finishes
                           whereas 'command' sends off one each time a command
                           finishes. 'All' implies 'final' and 'command'.

  --no-notify-action       Disables --notify-action.

  --notify-system (dbus | notify-send | apple-script)
                           The system used for sending notifications. 'dbus' and
                           'notify-send' available on linux, whereas
                           'apple-script' is available for osx.

  --no-notify-system       Disables --notify-system.

  --notify-timeout (never | NATURAL)
                           When to timeout success notifications. Defaults to 10
                           seconds.Note that the underlying notification system
                           may not support timeouts.

  --no-notify-timeout      Disables --notify-timeout.

  --default-config         Writes a default config.toml file to stdout.

  -h,--help                Show this help text

Version: 0.9
```

</details>

And here is the same with the new groups:

<details>
<summary>Click to expand</summary>

```
Shrun: A tool for running shell commands concurrently.

Usage: shrun [-c|--config PATH] [-i|--init STRING] 
             [-t|--timeout (NATURAL | STRING)] [--common-log-key-hide] 
             [--command-log-poll-interval NATURAL] 
             [--command-log-read-size BYTES] [--console-log-command] 
             [--console-log-command-name-trunc NATURAL] 
             [--console-log-line-trunc (NATURAL | detect)] 
             [--console-log-strip-control (all | smart | none)] 
             [--console-log-timer-format (digital_compact | digital_full | prose_compact | prose_full)]
             [-f|--file-log (default | PATH)] 
             [--file-log-command-name-trunc NATURAL] 
             [--file-log-delete-on-success] 
             [--file-log-line-trunc (NATURAL | detect)] 
             [--file-log-mode (append | write)] 
             [--file-log-size-mode (warn BYTES | delete BYTES | nothing)] 
             [--file-log-strip-control (all | smart | none)] 
             [--notify-action (final |command | all)] 
             [--notify-system (dbus | notify-send | apple-script)] 
             [--notify-timeout (never | NATURAL)] [--default-config] 
             [-v|--version] Commands...

  Shrun runs shell commands concurrently. In addition to providing basic timing
  and logging functionality, we also provide the ability to pass in a config
  file that can be used to define aliases for commands.

  In general, each option --foo has a --no-foo variant that disables cli and
  toml configuration for that field. For example, the --no-console-log-command
  option will instruct shrun to ignore both cli --console-log-command and toml
  console-log.command, ensuring the default behavior is used (i.e. no command
  logging).

  See github.com/tbidne/shrun#README for full documentation.

Available options:
  -c,--config PATH         Path to TOML config file. If this argument is not
                           given we automatically look in the XDG config
                           directory e.g. ~/.config/shrun/config.toml. The
                           --no-config option disables --config and the
                           automatic XDG lookup.

  --no-config              Disables --config.

  -i,--init STRING         If given, init is run before each command. That is,
                           'shrun --init ". ~/.bashrc" foo bar' is equivalent to
                           'shrun ". ~/.bashrc && foo" ". ~/.bashrc && bar"'.

  --no-init                Disables --init.

  -t,--timeout (NATURAL | STRING)
                           Non-negative integer setting a timeout. Can either be
                           a raw number (interpreted as seconds), or a "time
                           string" e.g. 1d2h3m4s or 2h3s. Defaults to no
                           timeout.

  --no-timeout             Disables --timeout.

  --default-config         Writes a default config.toml file to stdout.

  -h,--help                Show this help text

Command Logging:
  --command-log-poll-interval NATURAL
                           Non-negative integer used in conjunction with
                           --console-log-command and --file-log that determines
                           how quickly we poll commands for logs, in
                           microseconds. A value of 0 is interpreted as infinite
                           i.e. limited only by the CPU. Defaults to 10,000.
                           Note that lower values will increase CPU usage. In
                           particular, 0 will max out a CPU thread.

  --no-command-log-poll-interval
                           Disables --command-log-poll-interval.

  --command-log-read-size BYTES
                           The max number of bytes in a single read when
                           streaming command logs (--console-log-command and
                           --file-log). Logs larger than --command-log-read-size
                           will be read in a subsequent read, hence broken
                           across lines. The default is '1 kb'.

  --no-command-log-read-size
                           Disables --command-log-read-size.


Common Logging:
  --common-log-key-hide    By default, we display the key name from the legend
                           over the actual command that was run, if the former
                           exists. This flag instead shows the literal command.
                           Commands without keys are unaffected.

  --no-common-log-key-hide Disables --common-log-key-hide.


Console Logging:
  --console-log-command    The default behavior is to swallow logs for the
                           commands themselves. This flag gives each command a
                           console region in which its logs will be printed.
                           Only the latest log per region is show at a given
                           time.

  --no-console-log-command Disables --console-log-command.

  --console-log-command-name-trunc NATURAL
                           Non-negative integer that limits the length of
                           commands/key-names in the console logs. Defaults to
                           no truncation.

  --no-console-log-command-name-trunc
                           Disables --console-log-command-name-trunc.

  --console-log-line-trunc (NATURAL | detect)
                           Non-negative integer that limits the length of
                           console logs. Can also be the string literal
                           'detect', to detect the terminal size automatically.
                           Defaults to no truncation. Note that "log prefixes"
                           (e.g. labels like [Success], timestamps) are counted
                           towards the total length but are never truncated.

  --no-console-log-line-trunc
                           Disables --console-log-line-trunc.

  --console-log-strip-control (all | smart | none)
                           Control characters can wreak layout havoc, thus we
                           include this option. 'all' strips all such chars.
                           'none' does nothing i.e. all chars are left
                           untouched. The default 'smart' attempts to strip only
                           the control chars that affect layout (e.g. cursor
                           movements) and leaves others unaffected (e.g.
                           colors). This has the potential to be the 'prettiest'
                           though it is possible to miss some chars. This option
                           is experimental and subject to change.

  --no-console-log-strip-control
                           Disables --console-log-strip-control.

  --console-log-timer-format (digital_compact | digital_full | prose_compact | prose_full)
                           How to format the timer. Defaults to prose_compact
                           e.g. '2 hours, 3 seconds'.

  --no-console-log-timer-format
                           Disables --console-log-timer-format.


File Logging:
  -f,--file-log (default | PATH)
                           If a path is supplied, all logs will additionally be
                           written to the supplied file. Furthermore, command
                           logs will be written to the file irrespective of
                           --console-log-command. Console logging is unaffected.
                           This can be useful for investigating command
                           failures. If the string 'default' is given, then we
                           write to the XDG state directory e.g.
                           ~/.local/state/shrun/shrun.log.

  --no-file-log            Disables --file-log.

  --file-log-command-name-trunc NATURAL
                           Like --console-log-command-name-trunc, but for
                           --file-logs.

  --no-file-log-command-name-trunc
                           Disables --file-log-command-name-trunc.

  --file-log-delete-on-success
                           If --file-log is active, deletes the file on a
                           successful exit. Does not delete the file if shrun
                           exited via failure.

  --no-file-log-delete-on-success
                           Disables --file-log-delete-on-success.

  --file-log-line-trunc (NATURAL | detect)
                           Like --console-log-line-trunc, but for --file-log.

  --no-file-log-line-trunc Disables --file-log-line-trunc.

  --file-log-mode (append | write)
                           Mode in which to open the log file. Defaults to
                           write.

  --no-file-log-mode       Disables --file-log-mode.

  --file-log-size-mode (warn BYTES | delete BYTES | nothing)
                           Sets a threshold for the file log size, upon which we
                           either print a warning or delete the file, if it is
                           exceeded. The BYTES should include the value and
                           units e.g. warn 10 mb, warn 5 gigabytes, delete
                           20.5B. Defaults to warning at 50 mb.

  --no-file-log-size-mode  Disables --file-log-size-mode.

  --file-log-strip-control (all | smart | none)
                           --console-log-strip-control for file logs created
                           with --file-log. Defaults to all.

  --no-file-log-strip-control
                           Disables --file-log-strip-control.


Notifications:
  --notify-action (final |command | all)
                           Sends notifications for various actions. 'Final'
                           sends off a notification when Shrun itself finishes
                           whereas 'command' sends off one each time a command
                           finishes. 'All' implies 'final' and 'command'.

  --no-notify-action       Disables --notify-action.

  --notify-system (dbus | notify-send | apple-script)
                           The system used for sending notifications. 'dbus' and
                           'notify-send' available on linux, whereas
                           'apple-script' is available for osx.

  --no-notify-system       Disables --notify-system.

  --notify-timeout (never | NATURAL)
                           When to timeout success notifications. Defaults to 10
                           seconds.Note that the underlying notification system
                           may not support timeouts.

  --no-notify-timeout      Disables --notify-timeout.


Version: 0.9
```

</details>

# Remarks

- There is a question of what to do in the nested case e.g.

    ```haskell
    parserOptionGroup "General group" $
      (,)
        <$> parserA
        <*> parserOptionGroup "B group" parserB
    ```

    Currently, nested groups are concatenated i.e. `General group.B group`.

    <details>
    <summary>Click to expand outdated description</summary>
    I chose to always override the group, so in this case both `parserA` and `parserB` will be part of `General Group`. I judged this simpler, but we could choose instead to only overwrite the group when it is `Nothing`. This would render `parserA` in `General Group` and `parserB` in `B group` (flat; rendering is never nested).

    See the comment on `optPropertiesGroup` in [Builder.hs](https://github.com/pcapriotti/optparse-applicative/pull/486/files#diff-174f3ebe4eb81b46f9ad83982911c36d5d62daff8b044444ab3a6b5e3e033a59R383).

    </details>

- Another question concerns duplicate groups e.g.

    ```haskell
    a <- parserOptionGroup "Group A" parserA
    b <- parserOptionGroup "Group B" parserB
    b2 <- parserOptionGroup "Group B" parserB2
    c <- parserOptionGroup "Group A" parserC
    ```

    We treat these the same as command groups, that is, duplicate groups are only merged when they are _consecutive_. The above example will render three groups, `Group A`, `Group B`, `Group A`.

    <details>
    <summary>Click to expand outdated description</summary>
    I chose to make groups unique i.e. both parserA and parserC will go in the same `Group A`.

    See the comment on `sortGroupFst` in [Internal.hs](https://github.com/pcapriotti/optparse-applicative/pull/486/files#diff-6a3561af0fb3784021c76c183bbb8d87963ffd23bf7b3f7a315eb81d3c2da77fR275).
    </details>

- I'm not very familiar with optparse's internals, so please do let me know if I've missed anything obvious. I'm not married to this design, but I would really like to make _some_ progress here.

Thanks!