### PR TITLE
Fix broken Haddock links

### DIFF
--- a/src/Options/Applicative.hs
+++ b/src/Options/Applicative.hs
@@ -121,12 +121,13 @@ module Options.Applicative (
   -- the data passed by the user on the command line into a data type.
   --
   -- The most common are 'str' which is used for 'String' like types,
-  -- including 'ByteString' and 'Text'; and 'auto', which uses the 'Read'
-  -- typeclass, and is good for simple types like 'Int' or 'Double'.
+  -- including t'Data.ByteString.ByteString' and t'Data.Text.Text'; and 'auto',
+  -- which uses the 'Read' typeclass, and is good for simple types like 'Int' or
+  -- 'Double'.
   --
   -- More complex types can use the 'eitherReader' or 'maybeReader'
   -- functions to pattern match or use a more expressive parser like a
-  -- member of the 'Parsec' family.
+  -- member of the @Parsec@ family.
   ReadM,
 
   auto,

--- a/src/Options/Applicative/Builder/Internal.hs
+++ b/src/Options/Applicative/Builder/Internal.hs
@@ -120,7 +120,8 @@ instance Semigroup (DefaultProp a) where
 -- Modifiers are instances of 'Monoid', and can be composed as such.
 --
 -- One rarely needs to deal with modifiers directly, as most of the times it is
--- sufficient to pass them to builders (such as 'strOption' or 'flag') to
+-- sufficient to pass them to builders (such as 'Options.Applicative.strOption'
+-- or 'Options.Applicative.flag') to
 -- create options (see 'Options.Applicative.Builder').
 data Mod f a = Mod (f a -> f a)
                    (DefaultProp a)
@@ -184,7 +185,8 @@ mkProps (DefaultProp def sdef) g = props
 
 -- | Hide this option completely from the help text
 --
--- Use 'hidden' if the option should remain visible in the full description.
+-- Use 'Options.Applicative.hidden' if the option should remain visible in the
+-- full description.
 internal :: Mod f a
 internal = optionMod $ \p -> p { propVisibility = Internal }
 

--- a/src/Options/Applicative/Help/Chunk.hs
+++ b/src/Options/Applicative/Help/Chunk.hs
@@ -22,7 +22,7 @@ import Prelude
 
 import Options.Applicative.Help.Pretty
 
--- | The free monoid on a semigroup 'a'.
+-- | The free monoid on a semigroup @a@.
 newtype Chunk a = Chunk
   { unChunk :: Maybe a }
   deriving (Eq, Show)
@@ -53,7 +53,8 @@ instance MonadPlus Chunk where
   mzero = Chunk mzero
   mplus m1 m2 = Chunk $ mplus (unChunk m1) (unChunk m2)
 
--- | Given a semigroup structure on 'a', return a monoid structure on 'Chunk a'.
+-- | Given a semigroup structure on @a@, return a monoid structure on
+-- @'Chunk' a@.
 --
 -- Note that this is /not/ the same as 'liftA2'.
 chunked :: (a -> a -> a)

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -175,8 +175,9 @@ data Option a = Option
 
 data SomeParser = forall a . SomeParser (Parser a)
 
--- | Subparser context, containing the 'name' of the subparser and its parser info.
---   Used by parserFailure to display relevant usage information when parsing inside a subparser fails.
+-- | Subparser context, containing the name of the subparser and its parser info.
+--   Used by 'Options.Applicative.Extra.parserFailure' to display relevant usage
+--   information when parsing inside a subparser fails.
 data Context = forall a. Context String (ParserInfo a)
 
 instance Show (Option a) where
@@ -251,7 +252,7 @@ instance Functor OptReader where
   fmap f (ArgReader cr) = ArgReader (fmap f cr)
   fmap f (CmdReader n cs) = CmdReader n ((fmap . fmap . fmap) f cs)
 
--- | A @Parser a@ is an option parser returning a value of type 'a'.
+-- | A @Parser a@ is an option parser returning a value of type @a@.
 data Parser a
   = NilP (Maybe a)
   | OptP (Option a)
@@ -342,7 +343,7 @@ instance Functor ParserFailure where
   fmap f (ParserFailure err) = ParserFailure $ \progn ->
     let (h, exit, cols) = err progn in (f h, exit, cols)
 
--- | Result of 'execParserPure'.
+-- | Result of 'Options.Applicative.execParserPure'.
 data ParserResult a
   = Success a
   | Failure (ParserFailure ParserHelp)


### PR DESCRIPTION
Fix all broken Haddock links. Now Haddock doesn't emit any warnings about out-of-scope identifiers.