### PR TITLE
[feat] allow passing list literals to mod builders

### DIFF
--- a/src/Options/Applicative/Builder.hs
+++ b/src/Options/Applicative/Builder.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeFamilies #-}
 module Options.Applicative.Builder (
   -- * Parser builders
   --
@@ -118,6 +119,7 @@ import Options.Applicative.Common
 import Options.Applicative.Types
 import Options.Applicative.Help.Pretty
 import Options.Applicative.Help.Chunk
+import GHC.IsList (IsList(..))
 
 -- Readers --
 
@@ -383,6 +385,11 @@ option r m = mkParser d g rdr
 newtype InfoMod a = InfoMod
   { applyInfoMod :: ParserInfo a -> ParserInfo a }
 
+instance IsList (InfoMod a) where
+  type Item (InfoMod a) = InfoMod a
+  fromList = mconcat
+  toList = pure
+
 instance Monoid (InfoMod a) where
   mempty = InfoMod id
   mappend = (<>)
@@ -473,6 +480,11 @@ newtype PrefsMod = PrefsMod
 instance Monoid PrefsMod where
   mempty = PrefsMod id
   mappend = (<>)
+
+instance IsList PrefsMod where
+  type Item PrefsMod = PrefsMod
+  fromList = mconcat
+  toList = pure
 
 instance Semigroup PrefsMod where
   m1 <> m2 = PrefsMod $ applyPrefsMod m2 . applyPrefsMod m1

--- a/src/Options/Applicative/Builder/Internal.hs
+++ b/src/Options/Applicative/Builder/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 module Options.Applicative.Builder.Internal (
   -- * Internals
   Mod(..),
@@ -31,6 +32,7 @@ import Prelude
 
 import Options.Applicative.Common
 import Options.Applicative.Types
+import GHC.IsList (IsList(..))
 
 data OptionFields a = OptionFields
   { optNames :: [OptName]
@@ -126,6 +128,11 @@ instance Semigroup (DefaultProp a) where
 data Mod f a = Mod (f a -> f a)
                    (DefaultProp a)
                    (OptProperties -> OptProperties)
+
+instance IsList (Mod f a) where
+  type Item (Mod f a) = Mod f a
+  fromList = mconcat
+  toList = pure
 
 optionMod :: (OptProperties -> OptProperties) -> Mod f a
 optionMod = Mod id mempty


### PR DESCRIPTION
I have found myself writing things like `strOption $ mconcat [... ` quite often and upon discussion, @Qqwy suggested just using list literals, this PR implements this idea, it works like a charm. the `IsList` instance even respects its laws! 