### PR TITLE
Allow to tune behavior of the brief description renderer

### DIFF
--- a/src/Options/Applicative.hs
+++ b/src/Options/Applicative.hs
@@ -202,6 +202,7 @@ module Options.Applicative (
   helpLongEquals,
   helpShowGlobals,
   helpIndent,
+  briefHangPoint,
   defaultPrefs,
 
   -- * Completions

--- a/src/Options/Applicative/Builder.hs
+++ b/src/Options/Applicative/Builder.hs
@@ -90,6 +90,7 @@ module Options.Applicative.Builder (
   helpLongEquals,
   helpShowGlobals,
   helpIndent,
+  briefHangPoint,
   prefs,
   defaultPrefs,
 
@@ -582,6 +583,9 @@ helpShowGlobals = PrefsMod $ \p -> p { prefHelpShowGlobal = True }
 helpIndent :: Int -> PrefsMod
 helpIndent w = PrefsMod $ \p -> p { prefTabulateFill = w }
 
+-- | Set the width at which to hang the brief help text.
+briefHangPoint :: Int -> PrefsMod
+briefHangPoint php = PrefsMod $ \p -> p { prefBriefHangPoint = php }
 
 
 -- | Create a `ParserPrefs` given a modifier
@@ -597,7 +601,8 @@ prefs m = applyPrefsMod m base
       , prefColumns = 80
       , prefHelpLongEquals = False
       , prefHelpShowGlobal = False
-      , prefTabulateFill = 24 }
+      , prefTabulateFill = 24
+      , prefBriefHangPoint = 35 }
 
 -- Convenience shortcuts
 

--- a/src/Options/Applicative/Help/Core.hs
+++ b/src/Options/Applicative/Help/Core.hs
@@ -414,7 +414,7 @@ parserUsage pprefs p progn =
     hsep
       [ pretty "Usage:",
         pretty progn,
-        hangAtIfOver 9 35 (extractChunk (briefDesc pprefs p))
+        hangAtIfOver 9 (prefBriefHangPoint pprefs) (extractChunk (briefDesc pprefs p))
       ]
 
 -- | Peek at the structure of the rendered tree within.

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -127,7 +127,8 @@ data ParserPrefs = ParserPrefs
   , prefHelpShowGlobal :: Bool    -- ^ when displaying subparsers' usage help,
                                   -- show parent options under a "global options"
                                   -- section (default: False)
-  , prefTabulateFill ::Int       -- ^ Indentation width for tables
+  , prefTabulateFill ::Int        -- ^ Indentation width for tables
+  , prefBriefHangPoint :: Int     -- ^ Width at which to hang the brief description
   } deriving (Eq, Show)
 
 data OptName = OptShort !Char


### PR DESCRIPTION
# Context

First of all, thank you @HuwCampbell for your work on `optparse-applicative`. We (at [cardano-cli](https://github.com/input-output-hk/cardano-cli)) are very happy users of `optparse-applicative`!

This PR allows to tune the behavior of the renderer of descriptions. An option is added that favors vertical alignment when displaying multiple flags, instead of maximizing the use of space on a single line.

The default behavior is unchanged and no change is imposed upon users. This PR solely make it possible for callers that prefer vertical alignment to do so.

# Caveats

I am not super savvy about the different options that could be proposed. I have only proposed the existing behavior and the new one, which happen to yield very different results, as the change to the golden file of the changed test exemplifies:

![image](https://github.com/user-attachments/assets/30c57011-2ffa-49cb-9767-3c9b41e7d9e0)

We have many more examples at `cardano-cli` where we find this change beneficial in terms of readibility of the `--help` message when there are many flags available. For example:

![image](https://github.com/user-attachments/assets/ad24fd38-8647-4066-85da-072f1f321d6e)

Here is another one:

![image](https://github.com/user-attachments/assets/86a585d6-ea49-4341-9597-262aceac5566)

# History

For the record, this is an improvement that originally comes from https://github.com/pcapriotti/optparse-applicative/pull/428 and which we have maintained in [this fork](https://github.com/input-output-hk/optparse-applicative), but we now want to remove this fork, to shrink the spread in the Haskell ecosystem, and reduce maintenance burden.