### PR TITLE
Fix for #450

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.20.0.0 (Unreleased)
+
+- Fix for showHelpOnEmpty so that it works correctly when subParserInline is
+  also active.
+
+
 ## Version 0.19.0.0 (03 June 2025)
 
 - Add `briefHangPoint` modifier. This allows one to specify the command length


### PR DESCRIPTION
This is a slightly nicer implementation, in that it doesn't force two ways of supplying this information back to the help text generator.

The idea is that we already have a way of knowing when we enter a sub command with `enterContext`,with a little bit more information stored in the runner monad when we consume arguments, flags, and options, we can know if we're at the start.