### PR TITLE
revive the idea of supporting Selective

### DIFF
--- a/optparse-applicative.cabal
+++ b/optparse-applicative.cabal
@@ -114,6 +114,7 @@ library
                      , transformers                    >= 0.5   && < 0.7
                      , prettyprinter                   >= 1.7   && < 1.8
                      , prettyprinter-ansi-terminal     >= 1.1.2 && < 1.2
+                     , selective                       >= 0.4   && < 0.8
 
   if flag(process)
     build-depends:     process                         >= 1.0   && < 1.7

--- a/src/Options/Applicative/Common.hs
+++ b/src/Options/Applicative/Common.hs
@@ -55,6 +55,7 @@ import Control.Applicative
 import Control.Monad (guard, mzero, msum, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State (StateT(..), get, put, runStateT)
+import Control.Selective (select)
 import Data.List (isPrefixOf)
 import Data.Maybe (maybeToList, isJust, isNothing)
 import Prelude
@@ -270,7 +271,7 @@ evalParser (NilP r) = r
 evalParser (OptP _) = Nothing
 evalParser (MultP p1 p2) = evalParser p1 <*> evalParser p2
 evalParser (AltP p1 p2) = evalParser p1 <|> evalParser p2
-evalParser (SelectP p k) = evalParser p >>= either (\a -> ($ a) <$> evalParser k) pure
+evalParser (SelectP p k) = select (evalParser p) (evalParser k)
 evalParser (BindP p k) = evalParser p >>= evalParser . k
 
 -- | Map a polymorphic function over all the options of a parser, and collect

--- a/src/Options/Applicative/Common.hs
+++ b/src/Options/Applicative/Common.hs
@@ -147,6 +147,16 @@ searchParser f (MultP p1 p2) = foldr1 (<!>)
 searchParser f (AltP p1 p2) = msum
   [ searchParser f p1
   , searchParser f p2 ]
+searchParser f (SelectP p k) = msum
+  [ do p' <- searchParser f p
+       return $ SelectP p' k
+  , case evalParser p of
+      Nothing -> do
+        k' <- searchParser f k
+        return $ SelectP p k'
+      Just (Left a) -> fmap ($ a) <$> searchParser f k
+      Just (Right _) -> mzero
+  ]
 searchParser f (BindP p k) = msum
   [ do p' <- searchParser f p
        return $ BindP p' k
@@ -260,6 +270,7 @@ evalParser (NilP r) = r
 evalParser (OptP _) = Nothing
 evalParser (MultP p1 p2) = evalParser p1 <*> evalParser p2
 evalParser (AltP p1 p2) = evalParser p1 <|> evalParser p2
+evalParser (SelectP p k) = evalParser p >>= either (\a -> ($ a) <$> evalParser k) pure
 evalParser (BindP p k) = evalParser p >>= evalParser . k
 
 -- | Map a polymorphic function over all the options of a parser, and collect
@@ -306,6 +317,15 @@ treeMapParser g = simplify . go False g
             then MarkDefault
             else NoDefault
 
+    go r f (SelectP p k) =
+      case evalParser p of
+        Nothing -> do
+          MultNode [go r f p, AltNode MarkDefault [go r f k]]
+        Just (Left _) ->
+          MultNode [go r f p, go r f k]
+        Just (Right _) ->
+          MultNode []
+
     go r f (BindP p k) =
       let go' = go r f p
       in case evalParser p of
@@ -317,6 +337,7 @@ treeMapParser g = simplify . go False g
     hasArg (OptP p) = (isArg . optMain) p
     hasArg (MultP p1 p2) = hasArg p1 || hasArg p2
     hasArg (AltP p1 p2) = hasArg p1 || hasArg p2
+    hasArg (SelectP p1 p2) = hasArg p1 || hasArg p2
     hasArg (BindP p _) = hasArg p
 
 simplify :: OptTree a -> OptTree a

--- a/src/Options/Applicative/Internal.hs
+++ b/src/Options/Applicative/Internal.hs
@@ -292,4 +292,5 @@ mapParserOptions f = go
     go (OptP o) = OptP (f o)
     go (MultP p1 p2) = MultP (go p1) (go p2)
     go (AltP p1 p2) = AltP (go p1) (go p2)
+    go (SelectP p1 p2) = SelectP (go p1) (go p2)
     go (BindP p1 p2) = BindP (go p1) (\x -> go (p2 x))

--- a/src/Options/Applicative/Types.hs
+++ b/src/Options/Applicative/Types.hs
@@ -280,7 +280,7 @@ instance Functor Parser where
   fmap f (NilP x) = NilP (fmap f x)
   fmap f (OptP opt) = OptP (fmap f opt)
   fmap f (MultP p1 p2) = MultP (fmap (f.) p1) p2
-  fmap f (SelectP p1 p2) = SelectP (fmap (fmap f) p1) (fmap (fmap f) p2)
+  fmap f (SelectP p k) = SelectP (fmap (fmap f) p) (fmap (f.) k)
   fmap f (AltP p1 p2) = AltP (fmap f p1) (fmap f p2)
   fmap f (BindP p k) = BindP p (fmap f . k)
 


### PR DESCRIPTION
Hello,

this PR is essentially the branch mentioned by @HuwCampbell in issue #352 with minor updates (rebased, versions bumped, and some minor cleaning).

I think it would be great to have Selectives in optparse-applicative, in order to support various sensible ways of defaulting the options -- my target use-case is specifying input/output file formats, which may be guessed from the filename suffix (in which case the format option isn't required), but should throw an error if the guess is impossible. The selective interface allows handling of such error very nicely within the optparse error-printing scheme, instead of having to print a custom error message after parsing.

Notably, similar functionality is possible with the `ParserM` interface, but it's somewhat ugly for usual Monad vs. Selective purposes (the "continuation" branch requires a parameter to materialize, so it can't really get analyzed statically, thus there's no general way to get help for the options out of that).

An example for why this is IMO good is:

```hs
import Control.Selective
import Data.List
import Options.Applicative

guess :: String -> Maybe String -> Either String (String, String)
guess x ty'
  | Just ty <- ty' = Right (ty, x)
  | ".md" `isSuffixOf` x = Right ("markdown", x)
  | ".png" `isSuffixOf` x = Right ("picture", x)
  | otherwise = Left x

opts =
  select
    (guess
       <$> strOption (long "filename" <> help "input")
       <*> optional
             (strOption
                $ long "type"
                    <> metavar "TYPE"
                    <> hidden
                    <> help "input type (defaulted from file name)"))
    ((,) <$> strOption (long "type" <> metavar "markdown|picture"))

main = execParser (info (opts <**> helper) mempty) >>= print
```

Help prints out quite sensibly as:
```
ghci> :main -h
Usage: <interactive> --filename ARG [--type markdown|picture]

Available options:
  --filename ARG           input
  --type TYPE              input type (defaulted from file name)
  -h,--help                Show this help text
```

In the example, the argument is defaulted just right:
```
ghci> :main --filename test.png
("picture","test.png")
```

In case of unknown filetype the error message is relatively sensible:
```
ghci> :main --filename test.jpg
Missing: --type markdown|picture

Usage: <interactive> --filename ARG [--type markdown|picture]
```

```
ghci> :main --filename test.jpg --type picture
("picture","test.jpg")
```

One can ofc juggle the options a bit (e.g., hide various subsets of them in various situations) to achieve variations on the final effect.

On a minor note, I'm not sure if the implementation is completely OK -- I found that e.g. this https://github.com/exaexa/optparse-applicative/commit/cb2344f3de3579a199830014eaf85a730f60647c#diff-0881f202d8624335f28737091abea8a17f3e203e5e8e3ca398764fde24e91b93R153 works as well and I wasn't able to find a testcase that would help me understand if one of these would be strictly better. Any advice on that very welcome.

I can write a little bit of documentation; e.g. some simplified version of the above example could go to the Selective instance. If desirable, please let me know, will do.

Thanks!
-mk