### PR TITLE
remove fullDesc from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ main :: IO ()
 main = greet =<< execParser opts
   where
     opts = info (sample <**> helper)
-      ( fullDesc
-     <> progDesc "Print a greeting for TARGET"
+      ( progDesc "Print a greeting for TARGET"
      <> header "hello - a test for optparse-applicative" )
 
 greet :: Sample -> IO ()


### PR DESCRIPTION
Changelog for 0.20 says that `fullDesc` is removed (and didn't really do much for a few releases). This simply removes it from the README example, so that people who install 0.20 now for any reason (like me, naively pulling stuff from git :D ) don't get surprised.

Thanks!